### PR TITLE
Add pointer to the new co-located test suite #7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -766,12 +766,10 @@ This list is TBD!
 Tests
 ~~~~~
 
-TBD!
-
 To support the language-neutral testing of `purl` implementations, a test suite
-is provided as JSON document. This document contains an array of objects. Each
-object represents a test with these key/value pairs some of which may not be
-normalized:
+is provided as JSON document named `test-suite-data.json`. This JSON document
+contains an array of objects. Each object represents a test with these key/value
+pairs some of which may not be normalized:
 
 - **purl**: a `purl` string. 
 - **canonical**: the same `purl` string in canonical, normalized form


### PR DESCRIPTION
This is a minor doc update to remove the "TBD" and point to the test suite file that has been relocated here from its previous separate repo as per #7

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>