### PR TITLE
Adjust maven test-suite-data

### DIFF
--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -110,7 +110,7 @@
   {
     "description": "maven uses qualifiers",
     "purl": "Maven:org.apache.xmlgraphics/batik-anim@1.9.1?repositorY_url=repo.spring.io/release&classifier=sources",
-    "canonical_purl": "maven:org.apache.xmlgraphics/batik-anim@1.9.1?packaging=sources&repository_url=repo.spring.io/release",
+    "canonical_purl": "maven:org.apache.xmlgraphics/batik-anim@1.9.1?repository_url=repo.spring.io/release&classifier=sources",
     "type": "maven",
     "namespace": "org.apache.xmlgraphics",
     "name": "batik-anim",
@@ -122,7 +122,7 @@
   {
     "description": "maven pom reference",
     "purl": "Maven:org.apache.xmlgraphics/batik-anim@1.9.1?repositorY_url=repo.spring.io/release&type=pom",
-    "canonical_purl": "maven:org.apache.xmlgraphics/batik-anim@1.9.1?packaging=sources&repository_url=repo.spring.io/release&extension=pom",
+    "canonical_purl": "maven:org.apache.xmlgraphics/batik-anim@1.9.1?repository_url=repo.spring.io/release&type=pom",
     "type": "maven",
     "namespace": "org.apache.xmlgraphics",
     "name": "batik-anim",


### PR DESCRIPTION
Fixes some inconsistency introduced by: https://github.com/package-url/purl-spec/commit/d141f9cf14e5b268a5baf06ee54fbaff9ae9657e

It appears that the above change added some inconsistency in `purl` and `canonical_purl` wrt to changes to the qualifier names.  And in the case of the "maven pom reference" test-data, had an erroneous `packaging=sources` qualifier that doesn't make any sense (probably copy-pasta?)