### PR TITLE
Added space in version & qualifier + invalid qualifier key name

### DIFF
--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -262,5 +262,17 @@
     "qualifiers": null,
     "subpath": null,
     "is_invalid": false
+  },
+  {
+    "description": "valid maven purl containing a space in the version",
+    "purl": "pkg:maven/mygroup/myartifact@1.0.0%20Final",
+    "canonical_purl": "pkg:maven/mygroup/myartifact@1.0.0%20Final",
+    "type": "maven",
+    "namespace": "mygroup",
+    "name": "myartifact",
+    "version": "1.0.0 Final",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
   }
 ]

--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -274,5 +274,17 @@
     "qualifiers": {"mykey": "my value"},
     "subpath": null,
     "is_invalid": false
+  },
+  {
+    "description": "checks for invalid qualifier keys",
+    "purl": "pkg:npm/myartifact@1.0.0?in%20production=true",
+    "canonical_purl": null,
+    "type": "npm",
+    "namespace": null,
+    "name": "myartifact",
+    "version": "1.0.0",
+    "qualifiers": {"in production": "true"},
+    "subpath": null,
+    "is_invalid": true
   }
 ]

--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -264,14 +264,14 @@
     "is_invalid": false
   },
   {
-    "description": "valid maven purl containing a space in the version",
-    "purl": "pkg:maven/mygroup/myartifact@1.0.0%20Final",
-    "canonical_purl": "pkg:maven/mygroup/myartifact@1.0.0%20Final",
+    "description": "valid maven purl containing a space in the version and qualifier",
+    "purl": "pkg:maven/mygroup/myartifact@1.0.0%20Final?mykey=my%20value",
+    "canonical_purl": "pkg:maven/mygroup/myartifact@1.0.0%20Final?mykey=my%20value",
     "type": "maven",
     "namespace": "mygroup",
     "name": "myartifact",
     "version": "1.0.0 Final",
-    "qualifiers": null,
+    "qualifiers": {"mykey": "my value"},
     "subpath": null,
     "is_invalid": false
   }


### PR DESCRIPTION
In this example, the purl and canonicalized version should be the same but it a good test of the implementations use of encoding and decoding on this field.

Signed off by: Steve Springett