### PR TITLE
README: Debian: extend to specify source packages

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -38,7 +38,7 @@ bitbucket
       pkg:bitbucket/birkenfeld/pygments-main@244fd47e07d1014f0aed9c
 
 cocoapods
------
+---------
 ``cocoapods`` for Cocoapods:
 
 - The default repository is ``https://cdn.cocoapods.org/``

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -129,13 +129,20 @@ deb
 - The ``namespace`` is the "vendor" name such as "debian" or "ubuntu".
   It is not case sensitive and must be lowercased.
 - The ``name`` is not case sensitive and must be lowercased.
-- The ``version`` is the package version.
-- ``arch`` is the qualifiers key for a package architecture
+- The ``version`` is the version of the binary (or source) package.
+- ``arch`` is the qualifiers key for a package architecture. The special
+  value ``arch=source`` shall identify a Debian source package (which
+  usually consists of a Debian Source control file (.dsc) and corresponding
+  upstream and Debian sources). In this case, ``name`` and ``version`` of the
+  source package shall be given (both may differ from binary package!), as
+  printed by ``dpkg-query -f '${source:Package} ${source:Version} -W <pkg>``.
 - Examples::
 
       pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie
       pkg:deb/debian/dpkg@1.19.0.4?arch=amd64&distro=stretch
       pkg:deb/ubuntu/dpkg@1.19.0.4?arch=amd64
+      pkg:deb/debian/attr@1:2.4.47-2?arch=source
+      pkg:deb/debian/attr@1:2.4.47-2%2Bb1?arch=amd64
 
 docker
 ------

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -130,12 +130,14 @@ deb
   It is not case sensitive and must be lowercased.
 - The ``name`` is not case sensitive and must be lowercased.
 - The ``version`` is the version of the binary (or source) package.
-- ``arch`` is the qualifiers key for a package architecture. The special
-  value ``arch=source`` shall identify a Debian source package (which
-  usually consists of a Debian Source control file (.dsc) and corresponding
-  upstream and Debian sources). In this case, ``name`` and ``version`` of the
-  source package shall be given (both may differ from binary package!), as
-  printed by ``dpkg-query -f '${source:Package} ${source:Version} -W <pkg>``.
+- ``arch`` is the qualifiers key for a package architecture. The special value
+  ``arch=source`` identifies a Debian source package that usually consists of a
+  Debian Source control file (.dsc) and corresponding upstream and Debian
+  sources. The ``dpkg-query`` command can print the ``name`` and ``version`` of
+  the corresponding source package of a binary package::
+
+    dpkg-query -f '${source:Package} ${source:Version}' -W <binary package name>
+
 - Examples::
 
       pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie


### PR DESCRIPTION
In technical as well as compliance contexts, we often need to refer to Debian sources for a package. Often there is no trivial mapping between source and binary packages (several binaries built from one source,
names as well as versions can differ between binary and source packages!), so to avoid confusion, package-urls shall allow to explicitely specify source packages.  After some internal discussion, we
think that an extra qualifier "type" is needed - which shall prevail the "arch" qualifier.