### PR TITLE
rearrange qualifier order in test suite to match canonical purl

### DIFF
--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -109,7 +109,7 @@
   },
   {
     "description": "maven often uses qualifiers",
-    "purl": "pkg:Maven/org.apache.xmlgraphics/batik-anim@1.9.1?repositorY_url=repo.spring.io/release&classifier=sources",
+    "purl": "pkg:Maven/org.apache.xmlgraphics/batik-anim@1.9.1?classifier=sources&repositorY_url=repo.spring.io/release",
     "canonical_purl": "pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?classifier=sources&repository_url=repo.spring.io/release",
     "type": "maven",
     "namespace": "org.apache.xmlgraphics",
@@ -121,7 +121,7 @@
   },
   {
     "description": "maven pom reference",
-    "purl": "pkg:Maven/org.apache.xmlgraphics/batik-anim@1.9.1?repositorY_url=repo.spring.io/release&extension=pom",
+    "purl": "pkg:Maven/org.apache.xmlgraphics/batik-anim@1.9.1?extension=pom&repositorY_url=repo.spring.io/release",
     "canonical_purl": "pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?extension=pom&repository_url=repo.spring.io/release",
     "type": "maven",
     "namespace": "org.apache.xmlgraphics",
@@ -133,7 +133,7 @@
   },
   {
     "description": "maven can come with a type qualifier",
-    "purl": "pkg:Maven/net.sf.jacob-project/jacob@1.14.3?type=dll&classifier=x86",
+    "purl": "pkg:Maven/net.sf.jacob-project/jacob@1.14.3?classifier=x86&type=dll",
     "canonical_purl": "pkg:maven/net.sf.jacob-project/jacob@1.14.3?classifier=x86&type=dll",
     "type": "maven",
     "namespace": "net.sf.jacob-project",


### PR DESCRIPTION
In some of the test cases the qualifiers are not listed in the same order for the `purl` and the `canonical_purl`. I think these should be aligned. On the one hand for symmetry, on the other hand I think it would make sense for libraries in general to preserve qualifier order such that a parsed purl results in the same URI when converted back to a string. If so, the test suite needs to align qualifier ordering between `purl` and `canonical_purl`.

