### PR TITLE
Fix docker example with repository_url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ Some `purl` examples
     pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie
 
     pkg:docker/cassandra@sha256:244fd47e07d1004f0aed9c
-    pkg:docker/gcr.io/customer/dockerimage@sha256:244fd47e07d1004f0aed9c
+    pkg:docker/customer/dockerimage@sha256:244fd47e07d1004f0aed9c?repository_url=gcr.io
 
     pkg:gem/jruby-launcher@1.1.2?platform=java
     pkg:gem/ruby-advisory-db-check@0.12.4
@@ -543,7 +543,7 @@ candidate list further down.
 
         pkg:docker/cassandra@latest
         pkg:docker/smartentry/debian@dc437cc87d10
-        pkg:docker/gcr.io/customer/dockerimage@sha256%3A244fd47e07d10
+        pkg:docker/customer/dockerimage@sha256%3A244fd47e07d10?repository_url=gcr.io
 
 
 - `gem` for Rubygems:


### PR DESCRIPTION
The docker example where not correct according to the spec. E.g. https://github.com/package-url/purl-spec/blob/18fa4e7b3eeb87d529318592f92a40e964f5f2e5/test-suite-data.json#L89