### PR TITLE
Proposal: Add homepage_url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,8 @@ The defintion for each components is:
 - **version**: the version of the package. Optional.
 - **qualifiers**: extra qualifying data for a package such as an OS,
   architecture, a distro, etc. Optional and type-specific.
+  Multiple qualifiers must be separated with "&" and the keys should be
+  sorted by key in the "C" locale.
 - **subpath**: extra subpath within a package, relative to the package root.
   Optional.
 
@@ -580,6 +582,11 @@ candidate list further down.
     the `generic` type and eventually contributed back to this specification
   - as for other `type`, the `name` component is mandatory. In the worst case
     it can be a file or directory name.
+  - A `homepage_url` may be provided in `qualifiers`; this identifies the
+    main "home page" for users to learn more about the software.
+    This is especially useful when no public `download_url` and `vcs_url`
+    are available.  It's also useful to help users find the correct
+    package home page.
   - Examples (truncated for brevity)::
 
        pkg:generic/openssl@1.1.10g


### PR DESCRIPTION
Many software packages do not have a publicly-accessible
version control system (VCS) nor a public download page.
If package-URL is to be able to identify arbitrary packages it
must be able to handle these cases. In addition, just having the VCS
information is sometimes not enough to learn more about the software.

This proposal adds `homepage_url` to `generic`. This makes it
possible to refer to these (many) programs, along with their version numbers.
The homepage URL is also really helpful to users, who may want to
know more about the program and the other information may not be enough
to help.

The CII Best Practices badge has had great success using
homepage URL and VCS URL as a unique project identifier, even for projects
which aren't under the control of a language-level packaging system.

This commit also adds information on how to handle multiple qualifier values
(separate with "&" and sort keys using the "C" locale).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>