### PR TITLE
Make Sonatype Lifecycle link stable in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ differences in syntax, naming and conventions:
   https://github.com/versioneye/
 
 - Sonatype Lifecycle uses a format id followed by format specific coordinates.
-  https://help.sonatype.com/iqserver/automating/rest-apis/component-details-rest-api---v2
+  https://links.sonatype.com/products/nxiq/doc/component-identifier
 
 
 Solution


### PR DESCRIPTION
Hi again,

Small follow-up to https://github.com/package-url/purl-spec/pull/111

We've improved it to be a stable link (apologies for the churn I should have done this initially).