### PR TITLE
Provide mode detail on namespace segments

### DIFF
--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -163,7 +163,7 @@ The rules for each component are:
   - Leading and trailing slashes '/' are not significant and should be stripped
     in the canonical form. They are not part of the `namespace`
   - Each `namespace` segment is a non-zero length string defined as a
-    restriction on rfc3986 segments.  `namespce` segments allow sequences of 
+    restriction on rfc3986 segments.  `namespace` segments allow sequences of 
     unreserved characters or a percent-encoded string
 
     - `segment       = pchar pchar*`

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -162,7 +162,15 @@ The rules for each component are:
     '/'
   - Leading and trailing slashes '/' are not significant and should be stripped
     in the canonical form. They are not part of the `namespace`
-  - Each `namespace` segment must be a percent-encoded string
+  - Each `namespace` segment is a non-zero length string defined as a
+    restriction on rfc3986 segments.  `namespce` segments allow sequences of 
+    unreserved characters or a percent-encoded string
+
+    - `segment       = pchar pchar*`
+    - `pchar         = unreserved / pct-encoded`
+    - `pct-encoded   = "%" HEXDIG HEXDIG`
+    - `unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"`
+
   - When percent-decoded, a segment:
 
     - must not contain a '/'


### PR DESCRIPTION
The specification provides examples of namespace segments
but does not provide a grammar to describe the.  Adopt a
restriction on the segments presented in rfc3986 to describe
namespaces.