### PR TITLE
Remove comment wrt. nuget namespace #8

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -245,7 +245,6 @@ nuget
 - The default repository is ``https://www.nuget.org``
 - There is no ``namespace`` per se even if the common convention is to use
   dot-separated package names where the first segment is ``namespace``-like.
-  TBD: should we split the first segment as a namespace?
 - Examples::
 
       pkg:nuget/EnterpriseLibrary.Common@6.0.1304


### PR DESCRIPTION
The namespace in nuget is conventional and part of the name.
This remove a dangling comment to revisit the topic but there
is nothing really to revisit.

Reference: https://github.com/package-url/purl-spec/issues/8
Reference: https://github.com/NuGet/Home/issues/6180#issuecomment-347056033
Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>