### PR TITLE
Fix default Conan repository

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -81,7 +81,7 @@ conan
 -----
 ``conan`` for Conan C/C++ packages:
 
-- The default repository is ``https://conan.io/center``
+- The default repository is ``https://center.conan.io``
 - The ``namespace`` is the user if present
 - The ``name`` is the package name.
 - The ``version`` is the package version.


### PR DESCRIPTION
The current default, `https://conan.io/center`, is what a user uses in
a web browser to search for packages. But the actual repository that the
Conan tool uses is `https://center.conan.io`.

Signed-off-by: Patrick Dwyer <patrick.dwyer@owasp.org>

Resolves #133 