### PR TITLE
fix: license detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+mit.LICENSE


### PR DESCRIPTION
Various tools use "LICENSE" as default location for the license (including the github license auto detection).
This PR renames mit.LICENSE to LICENSE.