### PR TITLE
docs(types): oci type qualifiers must be percent encoded

### DIFF
--- a/tests/types/generic-test.json
+++ b/tests/types/generic-test.json
@@ -46,7 +46,7 @@
       "description": "Parse test for PURL type: generic",
       "test_group": "base",
       "test_type": "parse",
-      "input": "pkg:generic/openssl@1.1.10g?download_url=https://openssl.org/source/openssl-1.1.0g.tar.gz&checksum=sha256:de4d501267da",
+      "input": "pkg:generic/openssl@1.1.10g?download_url=https:%2F%2Fopenssl.org%2Fsource%2Fopenssl-1.1.0g.tar.gz&checksum=sha256:de4d501267da",
       "expected_output": {
         "type": "generic",
         "namespace": null,
@@ -65,7 +65,7 @@
       "description": "Roundtrip test for PURL type: generic",
       "test_group": "base",
       "test_type": "roundtrip",
-      "input": "pkg:generic/openssl@1.1.10g?download_url=https://openssl.org/source/openssl-1.1.0g.tar.gz&checksum=sha256:de4d501267da",
+      "input": "pkg:generic/openssl@1.1.10g?download_url=https:%2F%2Fopenssl.org%2Fsource%2Fopenssl-1.1.0g.tar.gz&checksum=sha256:de4d501267da",
       "expected_output": "pkg:generic/openssl@1.1.10g?checksum=sha256:de4d501267da&download_url=https://openssl.org/source/openssl-1.1.0g.tar.gz",
       "expected_failure": false,
       "expected_failure_reason": null
@@ -93,7 +93,7 @@
       "description": "Parse test for PURL type: generic",
       "test_group": "base",
       "test_type": "parse",
-      "input": "pkg:generic/bitwarderl?vcs_url=git%2Bhttps://git.fsfe.org/dxtr/bitwarderl%40cc55108da32",
+      "input": "pkg:generic/bitwarderl?vcs_url=git%2Bhttps:%2F%2Fgit.fsfe.org%2Fdxtr%2Fbitwarderl%40cc55108da32",
       "expected_output": {
         "type": "generic",
         "namespace": null,
@@ -111,7 +111,7 @@
       "description": "Roundtrip test for PURL type: generic",
       "test_group": "base",
       "test_type": "roundtrip",
-      "input": "pkg:generic/bitwarderl?vcs_url=git%2Bhttps://git.fsfe.org/dxtr/bitwarderl%40cc55108da32",
+      "input": "pkg:generic/bitwarderl?vcs_url=git%2Bhttps:%2F%2Fgit.fsfe.org%2Fdxtr%2Fbitwarderl%40cc55108da32",
       "expected_output": "pkg:generic/bitwarderl?vcs_url=git%2Bhttps://git.fsfe.org/dxtr/bitwarderl%40cc55108da32",
       "expected_failure": false,
       "expected_failure_reason": null

--- a/tests/types/hex-test.json
+++ b/tests/types/hex-test.json
@@ -128,7 +128,7 @@
       "description": "Parse test for PURL type: hex",
       "test_group": "base",
       "test_type": "parse",
-      "input": "pkg:hex/bar@1.2.3?repository_url=https://myrepo.example.com",
+      "input": "pkg:hex/bar@1.2.3?repository_url=https:%2F%2Fmyrepo.example.com",
       "expected_output": {
         "type": "hex",
         "namespace": null,
@@ -146,7 +146,7 @@
       "description": "Roundtrip test for PURL type: hex",
       "test_group": "base",
       "test_type": "roundtrip",
-      "input": "pkg:hex/bar@1.2.3?repository_url=https://myrepo.example.com",
+      "input": "pkg:hex/bar@1.2.3?repository_url=https:%2F%2Fmyrepo.example.com",
       "expected_output": "pkg:hex/bar@1.2.3?repository_url=https://myrepo.example.com",
       "expected_failure": false,
       "expected_failure_reason": null

--- a/tests/types/npm-test.json
+++ b/tests/types/npm-test.json
@@ -137,7 +137,7 @@
       "description": "Parse test for PURL type: npm",
       "test_group": "base",
       "test_type": "parse",
-      "input": "pkg:npm/mypackage@12.4.5?vcs_url=git://host.com/path/to/repo.git%404345abcd34343",
+      "input": "pkg:npm/mypackage@12.4.5?vcs_url=git:%2F%2Fhost.com%2Fpath%2Fto%2Frepo.git%404345abcd34343",
       "expected_output": {
         "type": "npm",
         "namespace": null,
@@ -155,7 +155,7 @@
       "description": "Roundtrip test for PURL type: npm",
       "test_group": "base",
       "test_type": "roundtrip",
-      "input": "pkg:npm/mypackage@12.4.5?vcs_url=git://host.com/path/to/repo.git%404345abcd34343",
+      "input": "pkg:npm/mypackage@12.4.5?vcs_url=git:%2F%2Fhost.com%2Fpath%2Fto%2Frepo.git%404345abcd34343",
       "expected_output": "pkg:npm/mypackage@12.4.5?vcs_url=git://host.com/path/to/repo.git%404345abcd34343",
       "expected_failure": false,
       "expected_failure_reason": null

--- a/tests/types/oci-test.json
+++ b/tests/types/oci-test.json
@@ -5,7 +5,7 @@
       "description": "Parse test for PURL type: oci",
       "test_group": "advanced",
       "test_type": "parse",
-      "input": "pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=docker.io/library/debian&arch=amd64&tag=latest",
+      "input": "pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=docker.io%2Flibrary%2Fdebian&arch=amd64&tag=latest",
       "expected_output": {
         "type": "oci",
         "namespace": null,
@@ -25,7 +25,7 @@
       "description": "Roundtrip test for PURL type: oci",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": "pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=docker.io/library/debian&arch=amd64&tag=latest",
+      "input": "pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=docker.io%2Flibrary%2Fdebian&arch=amd64&tag=latest",
       "expected_output": "pkg:oci/debian@sha256:244fd47e07d10?arch=amd64&repository_url=docker.io/library/debian&tag=latest",
       "expected_failure": false,
       "expected_failure_reason": null
@@ -54,7 +54,7 @@
       "description": "Parse test for PURL type: oci",
       "test_group": "advanced",
       "test_type": "parse",
-      "input": "pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=ghcr.io/debian&tag=bullseye",
+      "input": "pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=ghcr.io%2Fdebian&tag=bullseye",
       "expected_output": {
         "type": "oci",
         "namespace": null,
@@ -73,7 +73,7 @@
       "description": "Roundtrip test for PURL type: oci",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": "pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=ghcr.io/debian&tag=bullseye",
+      "input": "pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=ghcr.io%2Fdebian&tag=bullseye",
       "expected_output": "pkg:oci/debian@sha256:244fd47e07d10?repository_url=ghcr.io/debian&tag=bullseye",
       "expected_failure": false,
       "expected_failure_reason": null
@@ -101,7 +101,7 @@
       "description": "Parse test for PURL type: oci",
       "test_group": "advanced",
       "test_type": "parse",
-      "input": "pkg:oci/static@sha256%3A244fd47e07d10?repository_url=gcr.io/distroless/static&tag=latest",
+      "input": "pkg:oci/static@sha256%3A244fd47e07d10?repository_url=gcr.io%2Fdistroless%2Fstatic&tag=latest",
       "expected_output": {
         "type": "oci",
         "namespace": null,
@@ -120,7 +120,7 @@
       "description": "Roundtrip test for PURL type: oci",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": "pkg:oci/static@sha256%3A244fd47e07d10?repository_url=gcr.io/distroless/static&tag=latest",
+      "input": "pkg:oci/static@sha256%3A244fd47e07d10?repository_url=gcr.io%2Fdistroless%2Fstatic&tag=latest",
       "expected_output": "pkg:oci/static@sha256:244fd47e07d10?repository_url=gcr.io/distroless/static&tag=latest",
       "expected_failure": false,
       "expected_failure_reason": null

--- a/types-doc/generic-definition.md
+++ b/types-doc/generic-definition.md
@@ -38,8 +38,8 @@ The structure of a PURL for this package type is:
 ## Examples
 
 - `pkg:generic/openssl@1.1.10g`
-- `pkg:generic/openssl@1.1.10g?download_url=https://openssl.org/source/openssl-1.1.0g.tar.gz&checksum=sha256:de4d501267da`
-- `pkg:generic/bitwarderl?vcs_url=git%2Bhttps://git.fsfe.org/dxtr/bitwarderl%40cc55108da32`
+- `pkg:generic/openssl@1.1.10g?download_url=https:%2F%2Fopenssl.org%2Fsource%2Fopenssl-1.1.0g.tar.gz&checksum=sha256:de4d501267da`
+- `pkg:generic/bitwarderl?vcs_url=git%2Bhttps:%2F%2Fgit.fsfe.org%2Fdxtr%2Fbitwarderl%40cc55108da32`
 
 ## Note
 

--- a/types-doc/hex-definition.md
+++ b/types-doc/hex-definition.md
@@ -40,4 +40,4 @@ The structure of a PURL for this package type is:
 - `pkg:hex/jason@1.1.2`
 - `pkg:hex/acme/foo@2.3.`
 - `pkg:hex/phoenix_html@2.13.3#priv/static/phoenix_html.js`
-- `pkg:hex/bar@1.2.3?repository_url=https://myrepo.example.com`
+- `pkg:hex/bar@1.2.3?repository_url=https:%2F%2Fmyrepo.example.com`

--- a/types-doc/npm-definition.md
+++ b/types-doc/npm-definition.md
@@ -41,4 +41,4 @@ The structure of a PURL for this package type is:
 
 - `pkg:npm/foobar@12.3.1`
 - `pkg:npm/%40angular/animation@12.3.1`
-- `pkg:npm/mypackage@12.4.5?vcs_url=git://host.com/path/to/repo.git%404345abcd34343`
+- `pkg:npm/mypackage@12.4.5?vcs_url=git:%2F%2Fhost.com%2Fpath%2Fto%2Frepo.git%404345abcd34343`

--- a/types-doc/oci-definition.md
+++ b/types-doc/oci-definition.md
@@ -43,9 +43,9 @@ The structure of a PURL for this package type is:
 
 ## Examples
 
-- `pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=docker.io/library/debian&arch=amd64&tag=latest`
-- `pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=ghcr.io/debian&tag=bullseye`
-- `pkg:oci/static@sha256%3A244fd47e07d10?repository_url=gcr.io/distroless/static&tag=latest`
+- `pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=docker.io%2Flibrary%2Fdebian&arch=amd64&tag=latest`
+- `pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=ghcr.io%2Fdebian&tag=bullseye`
+- `pkg:oci/static@sha256%3A244fd47e07d10?repository_url=gcr.io%2Fdistroless%2Fstatic&tag=latest`
 - `pkg:oci/hello-wasm@sha256:244fd47e07d10?tag=v1`
 
 ## Reference URLs

--- a/types/generic-definition.json
+++ b/types/generic-definition.json
@@ -29,7 +29,7 @@
   "note": "When possible another or a new purl type should be used instead of using the generic type and eventually contributed back to this specification. Example have been truncated for brevity",
   "examples": [
     "pkg:generic/openssl@1.1.10g",
-    "pkg:generic/openssl@1.1.10g?download_url=https://openssl.org/source/openssl-1.1.0g.tar.gz&checksum=sha256:de4d501267da",
-    "pkg:generic/bitwarderl?vcs_url=git%2Bhttps://git.fsfe.org/dxtr/bitwarderl%40cc55108da32"
+    "pkg:generic/openssl@1.1.10g?download_url=https:%2F%2Fopenssl.org%2Fsource%2Fopenssl-1.1.0g.tar.gz&checksum=sha256:de4d501267da",
+    "pkg:generic/bitwarderl?vcs_url=git%2Bhttps:%2F%2Fgit.fsfe.org%2Fdxtr%2Fbitwarderl%40cc55108da32"
   ]
 }

--- a/types/hex-definition.json
+++ b/types/hex-definition.json
@@ -28,6 +28,6 @@
     "pkg:hex/jason@1.1.2",
     "pkg:hex/acme/foo@2.3.",
     "pkg:hex/phoenix_html@2.13.3#priv/static/phoenix_html.js",
-    "pkg:hex/bar@1.2.3?repository_url=https://myrepo.example.com"
+    "pkg:hex/bar@1.2.3?repository_url=https:%2F%2Fmyrepo.example.com"
   ]
 }

--- a/types/npm-definition.json
+++ b/types/npm-definition.json
@@ -29,6 +29,6 @@
   "examples": [
     "pkg:npm/foobar@12.3.1",
     "pkg:npm/%40angular/animation@12.3.1",
-    "pkg:npm/mypackage@12.4.5?vcs_url=git://host.com/path/to/repo.git%404345abcd34343"
+    "pkg:npm/mypackage@12.4.5?vcs_url=git:%2F%2Fhost.com%2Fpath%2Fto%2Frepo.git%404345abcd34343"
   ]
 }

--- a/types/oci-definition.json
+++ b/types/oci-definition.json
@@ -40,9 +40,9 @@
     "https://github.com/opencontainers/distribution-spec"
   ],
   "examples": [
-    "pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=docker.io/library/debian&arch=amd64&tag=latest",
-    "pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=ghcr.io/debian&tag=bullseye",
-    "pkg:oci/static@sha256%3A244fd47e07d10?repository_url=gcr.io/distroless/static&tag=latest",
+    "pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=docker.io%2Flibrary%2Fdebian&arch=amd64&tag=latest",
+    "pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=ghcr.io%2Fdebian&tag=bullseye",
+    "pkg:oci/static@sha256%3A244fd47e07d10?repository_url=gcr.io%2Fdistroless%2Fstatic&tag=latest",
     "pkg:oci/hello-wasm@sha256:244fd47e07d10?tag=v1"
   ]
 }


### PR DESCRIPTION
This PR modified qualifiers values like url.

Some url-like values ​​in qualifiers have been URL-encoded.
* vcs_url
* repository_url
* download_url

---

[OCI specification](https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#oci)

> repository_url: A repository URL where the artifact may be found, but not intended as the only location. This value is encouraged to identify a location the content may be fetched

```
pkg:oci/static@sha256:<digest>?repository_url=gcr.io/distroless/static&tag=latest
```

[qualifiers specification](https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst#rules-for-each-purl-component) 
> A value must be a percent-encoded string


Must repository_url be percent-encoded? 