### PR TITLE
Add more specific details around normalised PyPI package naming per PEP 503

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -515,21 +515,22 @@ pypi
 ----
 ``pypi`` for Python packages:
 
-- The default repository is ``https://pypi.org``. (Previously  ``https://pypi.python.org``.)
-- PyPI treats ``-`` and ``_`` as the same character and is not case sensitive.
-  Therefore a PyPI package ``name`` must be lowercased and underscore ``_``
-  replaced with a dash ``-``.
+- The default repository is ``https://pypi.org``. (Previously ``https://pypi.python.org``.)
+- Per `PEP 503 <https://peps.python.org/pep-0503/#normalized-names>`_, normalized PyPI package names should be 
+  lowercased with all runs of the characters ``.``, ``-``, or ``_`` replaced with a single ``-`` character.
 - The ``file_name`` qualifier selects a particular distribution file
   (case-sensitive). For naming convention, see the Python Packaging User Guide on
   `source distributions <https://packaging.python.org/en/latest/specifications/source-distribution-format/#source-distribution-file-name>`_,
   `binary distributions <https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-name-convention>`_,
   and `platform compatibility tags <https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/>`_.
+
 - Examples::
 
       pkg:pypi/django@1.11.1
       pkg:pypi/django@1.11.1?filename=Django-1.11.1.tar.gz
       pkg:pypi/django@1.11.1?filename=Django-1.11.1-py2.py3-none-any.whl
       pkg:pypi/django-allauth@12.23
+      pkg:pypi/oslo-concurrency@4.5.0
 
 rpm
 ---


### PR DESCRIPTION
[PEP 503](https://peps.python.org/pep-0503/#normalized-names) specifies more detail around normalised PyPI package naming,
so referencing that and reflecting the wording from it for the PyPI package-url type.

Signed-off-by: Weston Steimel <author@code.w.steimel.me.uk>