### PR TITLE
Add `filename` qualifier to pypi.

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -461,9 +461,11 @@ pypi
 - PyPI treats ``-`` and ``_`` as the same character and is not case sensitive.
   Therefore a PyPI package ``name`` must be lowercased and underscore ``_``
   replaced with a dash ``-``.
+- The ``filename`` qualifier selects a particular distribution file (case-sensitive).
 - Examples::
 
       pkg:pypi/django@1.11.1
+      pkg:pypi/django@1.11.1?filename=Django-1.11.1-py2.py3-none-any.whl
       pkg:pypi/django-allauth@12.23
 
 rpm

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -519,10 +519,15 @@ pypi
 - PyPI treats ``-`` and ``_`` as the same character and is not case sensitive.
   Therefore a PyPI package ``name`` must be lowercased and underscore ``_``
   replaced with a dash ``-``.
-- The ``filename`` qualifier selects a particular distribution file (case-sensitive).
+- The ``file_name`` qualifier selects a particular distribution file
+  (case-sensitive). For naming convention, see the Python Packaging User Guide on
+  `source distributions <https://packaging.python.org/en/latest/specifications/source-distribution-format/#source-distribution-file-name>`_,
+  `binary distributions <https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-name-convention>`_,
+  and `platform compatibility tags <https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/>`_.
 - Examples::
 
       pkg:pypi/django@1.11.1
+      pkg:pypi/django@1.11.1?filename=Django-1.11.1.tar.gz
       pkg:pypi/django@1.11.1?filename=Django-1.11.1-py2.py3-none-any.whl
       pkg:pypi/django-allauth@12.23
 


### PR DESCRIPTION
This allows the PURL to specify the exact file that was used.

Fixes #90.