### PR TITLE
Add Ruby and Swift to list of known implementations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,6 +163,8 @@ Known implementations
 - in Python: https://github.com/package-url/packageurl-python
 - in Rust: https://github.com/package-url/packageurl-rs
 - in JS: https://github.com/package-url/packageurl-js
+- in Ruby: https://github.com/package-url/packageurl-ruby
+- in Swift: https://github.com/package-url/packageurl-swift
 
 
 Users, adopters and links


### PR DESCRIPTION
This PR updates the README to add links to [packageurl-ruby](https://github.com/package-url/packageurl-ruby) and [packageurl-swift](https://github.com/package-url/packageurl-swift).