### PR TITLE
add an example with `/` in namespace to README and SPEC

### DIFF
--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -69,6 +69,7 @@ Some ``purl`` examples
     pkg:nuget/EnterpriseLibrary.Common@6.0.1304
     pkg:pypi/django@1.11.1
     pkg:rpm/fedora/curl@7.50.3-1.fc25?arch=i386&distro=fedora-25
+    pkg:golang/github.com/gorilla/context@234fd47e07d1004f0aed9c
 
 
 A ``purl`` is a URL

--- a/README.rst
+++ b/README.rst
@@ -136,6 +136,8 @@ Some `purl` examples
     pkg:rpm/fedora/curl@7.50.3-1.fc25?arch=i386&distro=fedora-25
     pkg:rpm/opensuse/curl@7.56.1-1.1.?arch=i386&distro=opensuse-tumbleweed
 
+    pkg:swift/github.com/Alamofire/Alamofire@5.4.3
+
 (NB: some checksums are truncated for brevity)
 
 


### PR DESCRIPTION
I think it is not clear from the text in the README and the examples whether a `/` in the namespace needs to be escaped. This adds an example from `/test-suite-data.json` to the list of examples, to make that clear, that escaping should not be done.

### A follow-up question, that is not scope of this PR, would be:
given the PURL `pkg:swift/github.com%2FAlamofire/Alamofire@5.4.3` is `pkg:swift/github.com/Alamofire/Alamofire@5.4.3` its canonical form?
If yes, it should be added to the test cases.

Or, for having more fun and with looking at #63 : what is the canonical form of `pkg:golang/github.com%2Frussross%2Fblackfriday%2Fv2@v2.1.0`?