### PR TITLE
Revert "Fix missing percent-encoding in purl example with repository_url"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,7 +124,7 @@ Some `purl` examples
     pkg:golang/google.golang.org/genproto#googleapis/api/annotations
 
     pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?packaging=sources
-    pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?repository_url=repo.spring.io%2Frelease
+    pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?repository_url=repo.spring.io/release
 
     pkg:npm/%40angular/animation@12.3.1
     pkg:npm/foobar@12.3.1


### PR DESCRIPTION
This reverts commit 37626c43ace346f38f390f9266ef99eef654bf66.

Escaping slashes in qualifiers necessary and does not match the test cases nor the spec:
https://github.com/package-url/purl-spec/blob/37626c43ace346f38f390f9266ef99eef654bf66/test-suite-data.json#L110-L121

see also: https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst#character-encoding
