### PR TITLE
Fix URL of package-url rust-lang repository

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,7 +161,7 @@ Known implementations
 - for the JVM: https://github.com/package-url/packageurl-java,
   https://github.com/sonatype/package-url-java
 - in Python: https://github.com/package-url/packageurl-python
-- in Rust: https://github.com/package-url/packageurl-rs
+- in Rust: https://github.com/package-url/packageurl.rs
 - in JS: https://github.com/package-url/packageurl-js
 
 


### PR DESCRIPTION
Changed from `packageurl-rs` to `packageurl.rs` because that seems to be what the actual repo/fork is using.