### PR TITLE
Request to reserve the qpkg type

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -326,6 +326,20 @@ nuget
 
       pkg:nuget/EnterpriseLibrary.Common@6.0.1304
 
+qpkg
+----
+``qpkg`` for QNX packages:
+
+- There is no default package repository: this should be implied either from
+  the ``namespace`` or using a repository base URL as ``repository_url`` 
+  qualifiers key.
+- The ``namespace`` is the vendor. It is not case sensitive and must be
+  lowercased. The default ``namespace`` is ``blackberry``.
+- Examples::
+
+      pkg:qpkg/blackberry/com.qnx.sdp@7.0.0.SGA201702151847
+      pkg:qpkg/com.qnx.qnx710.foo.bar.qux@0.0.4.01449T202205040833L
+
 oci
 ------------
 ``oci`` for all artifacts stored in registries that conform to the

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -333,12 +333,12 @@ qpkg
 - There is no default package repository: this should be implied either from
   the ``namespace`` or using a repository base URL as ``repository_url`` 
   qualifiers key.
-- The ``namespace`` is the vendor. It is not case sensitive and must be
-  lowercased. The default ``namespace`` is ``blackberry``.
+- The ``namespace`` is the vendor of the package. It is not case sensitive and must be
+  lowercased.
 - Examples::
 
       pkg:qpkg/blackberry/com.qnx.sdp@7.0.0.SGA201702151847
-      pkg:qpkg/com.qnx.qnx710.foo.bar.qux@0.0.4.01449T202205040833L
+      pkg:qpkg/blackberry/com.qnx.qnx710.foo.bar.qux@0.0.4.01449T202205040833L
 
 oci
 ------------


### PR DESCRIPTION
BlackBerry respectfully requests reservation of the qpkg type to identify packages belonging to QNX's package manager. QNX is a commercial Unix-like real-time operating system, aimed primarily at the embedded systems market.