### PR TITLE
Add `rpmmod` package type

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -547,6 +547,27 @@ rpm
       pkg:rpm/fedora/curl@7.50.3-1.fc25?arch=i386&distro=fedora-25
       pkg:rpm/centerim@4.22.10-1.el6?arch=i686&epoch=1&distro=fedora-25
 
+rpmmod
+------
+``rpmmod`` for RPM modules.
+A `module <https://docs.fedoraproject.org/en-US/modularity/using-modules/>`
+is a set of RPM packages that represent a component and are usually installed together:
+
+- There is no default package repository: this should be implied either from
+  the ``distro`` qualifiers key or using a repository base URL as
+  ``repository_url`` qualifiers key.
+- The ``namespace`` is the vendor such as ``fedora``, ``centos``, or ``redhat``.
+  It is not case sensitive and must be lowercased.
+- The ``name`` is the RPM module name and is case sensitive.
+- The ``version`` is the combined stream, version, and context of an RPM module,
+  separated by a colon (``:``, encoded as ``%3A``).
+- ``arch`` is the qualifiers key for the architecture of the module's packages.
+- Examples::
+
+      pkg:rpmmod/fedora/nodejs@14%3A3620220301144317%3A5e5ad4a0?arch=aarch64&distro=fedora-36
+      pkg:rpmmod/centos/postgresql@12%3A8010120191120141335%3Ae4e244f9?arch=x86_64&distro=centos-8
+      pkg:rpmmod/redhat/squid@4%3A8040020210420090912%3A522a0ee4?arch=ppc64le&distro=rhel-8
+
 swid
 -----
 ``swid`` for ISO-IEC 19770-2 Software Identification (SWID) tags:


### PR DESCRIPTION
RPM modules are a concept in the RHEL/Fedora/CentOS land that allow for grouping of arbitrary RPMs. These modules have their own naming scheme and can be identified using their own purl type. The proposal here is to call that type `rpmmod`.

More about RPM modules can be found in either of these sources:

- https://docs.fedoraproject.org/en-US/modularity/using-modules/
- https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/installing_managing_and_removing_user-space_components/introduction-to-modules_using-appstream#module-streams_introduction-to-modules
- https://docs.centos.org/en-US/8-docs/managing-userspace-components/assembly_introduction-to-modules/

More about the naming convention for RPM modules can also be found here:

https://docs.fedoraproject.org/en-US/modularity/core-concepts/nsvca/#_nsvca_definition

An example of an the NodeJS 14 module on Fedora 36:

```bash
$ cat /etc/redhat-release
Fedora release 36 (Thirty Six)
$ dnf module --repo=fedora-modular info nodejs:14
Name             : nodejs
Stream           : 14
Version          : 3620220301144317
Context          : 5e5ad4a0
Architecture     : x86_64
Profiles         : common [d], development, minimal
Default profiles : common
Repo             : fedora-modular
Summary          : Javascript runtime
Description      : Node.js is a platform built on Chrome''s JavaScript runtime for easily building fast, scalable network applications. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient, perfect for data-intensive real-time applications that run across distributed devices.
Requires         : platform:[f36]
Artifacts        : c-ares-0:1.17.2-2.module_f36+13930+82e25793.src
                 : c-ares-0:1.17.2-2.module_f36+13930+82e25793.x86_64
                 : c-ares-debuginfo-0:1.17.2-2.module_f36+13930+82e25793.x86_64
                 [...list truncated...]
```