### PR TITLE
Add `huggingface` and `mlflow` package types

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -280,6 +280,20 @@ hex
       pkg:hex/bar@1.2.3?repository_url=https://myrepo.example.com
 
 
+huggingface
+------
+``huggingface`` for Hugging Face models
+
+- The default repository is ``https://huggingface.co``.
+- The ``namespace`` is the model repository username or organization, if present. It is case insensitive and must be lowercased.
+- The ``name`` is the model repository name. It is case insensitive and must be lowercased.
+- The ``version`` is the model revision Git commit hash. It is case insensitive and must be lowercased.
+- Examples::
+
+      pkg:huggingface/distilbert-base-uncased@043235d6088ecd3dd5fb5ca3592b6913fd516027
+      pkg:huggingface/microsoft/deberta-v3-base@559062ad13d311b87b2c455e67dcd5f1c8f65111?repository_url=https://hub-ci.huggingface.co
+
+
 maven
 -----
 ``maven`` for Maven JARs and related artifacts
@@ -299,6 +313,26 @@ maven
       pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?type=zip&classifier=dist
       pkg:maven/net.sf.jacob-projec/jacob@1.14.3?classifier=x86&type=dll
       pkg:maven/net.sf.jacob-projec/jacob@1.14.3?classifier=x64&type=dll
+
+
+mlflow
+------
+``mlflow`` for MLflow models (Azure ML, Databricks, etc.)
+
+- The repository is the MLflow tracking URI. There is no default. Examples:
+  - Azure ML: ``https://<region>.api.azureml.ms/mlflow/v1.0/subscriptions/<subscription-id>/resourceGroups/<resource-group-name>/providers/Microsoft.MachineLearningServices/workspaces/<workspace-name>``
+  - Azure Databricks: ``https://adb-<numbers>.<number>.azuredatabricks.net/api/2.0/mlflow``
+  - AWS Databricks: ``https://dbc-<alphanumeric>-<alphanumeric>.cloud.databricks.com/api/2.0/mlflow``
+  - GCP Databricks: ``https://<numbers>.<number>.gcp.databricks.com/api/2.0/mlflow``
+- The ``namespace`` is empty.
+- The ``name`` is the model name. It is case insensitive and must be lowercased.
+- The ``version`` is the model version.
+- Known qualifiers keys are: ``model_uuid`` and ``run_id`` as defined in the MLflow documentation. Both are case insensitive and must be lowercased.
+- Examples::
+
+      pkg:mlflow/moviereviews@6
+      pkg:mlflow/creditfraud@3?repository_url=https://adb-5245952564735461.0.azuredatabricks.net/api/2.0/mlflow
+      pkg:mlflow/trafficsigns@10?model_uuid=36233173b22f4c89b451f1228d700d49&run_id=410a3121-2709-4f88-98dd-dba0ef056b0a
 
 
 npm

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -282,7 +282,7 @@ hex
 
 huggingface
 ------
-``huggingface`` for Hugging Face models
+``huggingface`` for Hugging Face ML models
 
 - The default repository is ``https://huggingface.co``.
 - The ``namespace`` is the model repository username or organization, if present. It is case insensitive and must be lowercased.
@@ -317,13 +317,15 @@ maven
 
 mlflow
 ------
-``mlflow`` for MLflow models (Azure ML, Databricks, etc.)
+``mlflow`` for MLflow ML models (Azure ML, Databricks, etc.)
 
 - The repository is the MLflow tracking URI. There is no default. Examples:
+
   - Azure ML: ``https://<region>.api.azureml.ms/mlflow/v1.0/subscriptions/<subscription-id>/resourceGroups/<resource-group-name>/providers/Microsoft.MachineLearningServices/workspaces/<workspace-name>``
   - Azure Databricks: ``https://adb-<numbers>.<number>.azuredatabricks.net/api/2.0/mlflow``
   - AWS Databricks: ``https://dbc-<alphanumeric>-<alphanumeric>.cloud.databricks.com/api/2.0/mlflow``
   - GCP Databricks: ``https://<numbers>.<number>.gcp.databricks.com/api/2.0/mlflow``
+  
 - The ``namespace`` is empty.
 - The ``name`` is the model name. It is case insensitive and must be lowercased.
 - The ``version`` is the model version.

--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -466,5 +466,65 @@
     "qualifiers": null,
     "subpath": null,
     "is_invalid": true
+  },
+  {
+    "description": "minimal Hugging Face model",
+    "purl": "pkg:huggingface/distilbert-base-uncased@043235d6088ecd3dd5fb5ca3592b6913fd516027",
+    "canonical_purl": "pkg:huggingface/distilbert-base-uncased@043235d6088ecd3dd5fb5ca3592b6913fd516027",
+    "type": "huggingface",
+    "namespace": null,
+    "name": "distilbert-base-uncased",
+    "version": "043235d6088ecd3dd5fb5ca3592b6913fd516027",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "Hugging Face model with staging endpoint",
+    "purl": "pkg:huggingface/microsoft/deberta-v3-base@559062ad13d311b87b2c455e67dcd5f1c8f65111?repository_url=https://hub-ci.huggingface.co",
+    "canonical_purl": "pkg:huggingface/microsoft/deberta-v3-base@559062ad13d311b87b2c455e67dcd5f1c8f65111?repository_url=https://hub-ci.huggingface.co",
+    "type": "huggingface",
+    "namespace": "microsoft",
+    "name": "deberta-v3-base",
+    "version": "559062ad13d311b87b2c455e67dcd5f1c8f65111",
+    "qualifiers": {"repository_url": "https://hub-ci.huggingface.co"},
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "minimal MLflow model",
+    "purl": "pkg:mlflow/moviereviews@6",
+    "canonical_purl": "pkg:mlflow/moviereviews@6",
+    "type": "mlflow",
+    "namespace": null,
+    "name": "moviereviews",
+    "version": "6",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "MLflow model tracked in Azure Databricks",
+    "purl": "pkg:mlflow/creditfraud@3?repository_url=https://adb-5245952564735461.0.azuredatabricks.net/api/2.0/mlflow",
+    "canonical_purl": "pkg:mlflow/creditfraud@3?repository_url=https://adb-5245952564735461.0.azuredatabricks.net/api/2.0/mlflow",
+    "type": "mlflow",
+    "namespace": null,
+    "name": "creditfraud",
+    "version": "3",
+    "qualifiers": {"repository_url": "https://adb-5245952564735461.0.azuredatabricks.net/api/2.0/mlflow"},
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "MLflow model with unique identifiers",
+    "purl": "pkg:mlflow/trafficsigns@10?model_uuid=36233173b22f4c89b451f1228d700d49&run_id=410a3121-2709-4f88-98dd-dba0ef056b0a",
+    "canonical_purl": "pkg:mlflow/trafficsigns@10?model_uuid=36233173b22f4c89b451f1228d700d49&run_id=410a3121-2709-4f88-98dd-dba0ef056b0a",
+    "type": "mlflow",
+    "namespace": null,
+    "name": "trafficsigns",
+    "version": "10",
+    "qualifiers": {"model_uuid": "36233173b22f4c89b451f1228d700d49", "run_id": "410a3121-2709-4f88-98dd-dba0ef056b0a"},
+    "subpath": null,
+    "is_invalid": false
   }
 ]


### PR DESCRIPTION
This change enables tracking Machine Learning (ML) models stored in Hugging Face and MLflow (Azure ML, Databricks, etc.) model registries (#197).