### PR TITLE
docs: fix typo (defintion to definition)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ A `purl` is a URL composed of seven components::
 
 Components are separated by a specific character for unambiguous parsing.
 
-The defintion for each components is:
+The definition for each components is:
 
 - **scheme**: this is the URL scheme with the constant value of "pkg". One of
   the primary reason for this single scheme is to facilitate the future official


### PR DESCRIPTION
Hello, first of all, thank you for creating & marinating the spec!

Today I found a very simple typo, `defintion`, in README.  This PR fixes that. Hope it will be a very little help.