### PR TITLE
fix(test-suite-data): expect lexicographical sorting of qualifiers

### DIFF
--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -530,7 +530,7 @@
   {
     "description": "MLflow model with unique identifiers",
     "purl": "pkg:mlflow/trafficsigns@10?model_uuid=36233173b22f4c89b451f1228d700d49&run_id=410a3121-2709-4f88-98dd-dba0ef056b0a&repository_url=https://adb-5245952564735461.0.azuredatabricks.net/api/2.0/mlflow",
-    "canonical_purl": "pkg:mlflow/trafficsigns@10?model_uuid=36233173b22f4c89b451f1228d700d49&run_id=410a3121-2709-4f88-98dd-dba0ef056b0a&repository_url=https://adb-5245952564735461.0.azuredatabricks.net/api/2.0/mlflow",
+    "canonical_purl": "pkg:mlflow/trafficsigns@10?model_uuid=36233173b22f4c89b451f1228d700d49&repository_url=https://adb-5245952564735461.0.azuredatabricks.net/api/2.0/mlflow&run_id=410a3121-2709-4f88-98dd-dba0ef056b0a",
     "type": "mlflow",
     "namespace": null,
     "name": "trafficsigns",


### PR DESCRIPTION
Running into test failure for this test case only. I might've misunderstood the spec but I believe these should be lexicographically ordered?