### PR TITLE
[rpm] Add VMWare Photon Example

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -470,6 +470,7 @@ rpm
 
       pkg:rpm/fedora/curl@7.50.3-1.fc25?arch=i386&distro=fedora-25
       pkg:rpm/centerim@4.22.10-1.el6?arch=i686&epoch=1&distro=fedora-25
+      pkg:rpm/vmware/systemd?distro=photon-1
 
 swid
 -----


### PR DESCRIPTION
just for example purposes, to avoid confusion elsewhere.

There are lots of ways to represent this:

- `pkg:rpm/photon/systemd?distro=vmware-photon-1`
- `pkg:rpm/photon/systemd?distro=photon-1`
- `pkg:rpm/systemd?distro=vmware-photon-1`
- `pkg:rpm/systemd?distro=photon-1`

However, the representation in the example should hopefully be clear and provide some guidance.