### PR TITLE
Poposing optional media_type qualifier for OCI type purls

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -415,6 +415,8 @@ including container images built by Docker and others:
 - Optional qualifiers may include:
 
   - ``arch``: key for a package architecture, when relevant.
+  - ``media_type``: [Media type](https://github.com/opencontainers/image-spec/blob/main/media-types.md)
+    of the OCI object identified by the package URL (layer, manifest, config, etc).
   - ``repository_url``: A repository URL where the artifact may be found, but not
     intended as the only location. This value is encouraged to identify a
     location the content may be fetched.
@@ -425,6 +427,7 @@ including container images built by Docker and others:
       pkg:oci/debian@sha256%3A244fd47e07d10?repository_url=ghcr.io/debian&tag=bullseye
       pkg:oci/static@sha256%3A244fd47e07d10?repository_url=gcr.io/distroless/static&tag=latest
       pkg:oci/hello-wasm@sha256%3A244fd47e07d10?tag=v1
+      pkg:oci/static@sha256%3A953aad6dd4eb0?media_type=application%2Fvnd.oci.image.index.v1%2Bjson
 
 pub
 ----


### PR DESCRIPTION
This commit introduces a new `media_type` optional qualifier available to `oci`-typed purls to express the
type of OCI object they are identifying (image, manifest, layout, layer, etc).

Example purl identifying an index:

`pkg:oci/static@sha256%3A953aad6dd4eb0?media_type=application%2Fvnd.oci.image.index.v1%2Bjson`

/cc @rnjudge 