### PR TITLE
Add lowercase requirement to composer name

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -107,7 +107,7 @@ composer
 
 - The default repository is ``https://packagist.org``.
 - The ``namespace`` is the vendor.
-- The ``name`` is not case sensitive and must be lowercased.
+- The ``namespace`` and ``name`` are not case sensitive and must be lowercased.
 - Note: private, local packages may have no name. In this case you cannot
   create a ``purl`` for these.
 - Examples::

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -46,7 +46,7 @@ apk
 ``apk`` for APK-based packages:
 
 - There is no default package repository: this should be implied either from
-  the ``distro`` qualifiers key  or using a repository base url as 
+  the ``distro`` qualifiers key  or using a repository base url as
   ``repository_url`` qualifiers key.
 - The ``namespace`` is the vendor such as ``alpine`` or ``openwrt``. It is not
   case sensitive and must be lowercased.
@@ -107,6 +107,7 @@ composer
 
 - The default repository is ``https://packagist.org``.
 - The ``namespace`` is the vendor.
+- The ``name`` is not case sensitive and must be lowercased.
 - Note: private, local packages may have no name. In this case you cannot
   create a ``purl`` for these.
 - Examples::
@@ -342,7 +343,7 @@ mlflow
   - Azure Databricks: ``https://adb-<numbers>.<number>.azuredatabricks.net/api/2.0/mlflow``
   - AWS Databricks: ``https://dbc-<alphanumeric>-<alphanumeric>.cloud.databricks.com/api/2.0/mlflow``
   - GCP Databricks: ``https://<numbers>.<number>.gcp.databricks.com/api/2.0/mlflow``
-  
+
 - The ``namespace`` is empty.
 - The ``name`` is the model name. Case sensitivity depends on the server implementation:
 
@@ -387,7 +388,7 @@ qpkg
 ``qpkg`` for QNX packages:
 
 - There is no default package repository: this should be implied either from
-  the ``namespace`` or using a repository base URL as ``repository_url`` 
+  the ``namespace`` or using a repository base URL as ``repository_url``
   qualifiers key.
 - The ``namespace`` is the vendor of the package. It is not case sensitive and must be
   lowercased.

--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -538,5 +538,17 @@
     "qualifiers": {"model_uuid": "36233173b22f4c89b451f1228d700d49", "run_id": "410a3121-2709-4f88-98dd-dba0ef056b0a", "repository_url": "https://adb-5245952564735461.0.azuredatabricks.net/api/2.0/mlflow"},
     "subpath": null,
     "is_invalid": false
+  },
+  {
+    "description": "composer names are not case sensitive",
+    "purl": "pkg:composer/Laravel/Laravel@5.5.0",
+    "canonical_purl": "pkg:composer/laravel/laravel@5.5.0",
+    "type": "composer",
+    "namespace": "laravel",
+    "name": "laravel",
+    "version": "5.5.0",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
   }
 ]


### PR DESCRIPTION
This MR adds a requirement to have the `namespace` and `name` be lowercased since this is how names are expected by the [composer.lock](https://getcomposer.org/doc/04-schema.md#name) schema.