### PR TITLE
Remove cocoapods from canidate list

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -520,7 +520,6 @@ Other candidate types to define:
 - ``chef`` for Chef packages:
 - ``chocolatey`` for Chocolatey packages
 - ``clojars`` for Clojure packages:
-- ``cocoapods`` for Cocoapods iOS packages:
 - ``coreos`` for CoreOS packages:
 - ``cpan`` for CPAN Perl packages:
 - ``ctan`` for CTAN TeX packages:


### PR DESCRIPTION
cocoapods type appears to be defined in #125, this entry would seems to be outdated now.