### PR TITLE
Add GitHub Actions type

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -253,6 +253,23 @@ github
       pkg:github/package-url/purl-spec@244fd47e07d1004
       pkg:github/package-url/purl-spec@244fd47e07d1004#everybody/loves/dogs
 
+githubactions
+------
+``githubactions`` for GitHub Actions:
+
+- The ``namespace`` is the user or organization. It is not case sensitive and
+  must be lowercased.
+- The ``name`` is the repository name. It is not case sensitive and must be
+  lowercased.
+- The ``subpath`` is used to point to a secondary action within a repository. It is not case sensitive and must be lowercased.
+- The ``version`` is a commit or release tag. 
+- Examples::
+
+      pkg:githubactions/package-url/purl-spec@244fd47e07d1004
+      pkg:githubactions/package-url/purl-spec@v1.2
+      pkg:githubactions/github/codeql-action/analyze@v2
+
+
 golang
 ------
 ``golang`` for Go packages:

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -261,7 +261,7 @@ githubactions
   must be lowercased.
 - The ``name`` is the repository name. It is not case sensitive and must be
   lowercased.
-- The ``subpath`` is used to point to a secondary action within a repository. It is not case sensitive and must be lowercased.
+- The ``subpath`` is used to point to the location of an action within a repository in the event there are multiple defined. It is not case sensitive and must be lowercased. If omitted, the package-url refers to the default action for the repository only.
 - The ``version`` is a commit SHA or release tag. 
 - The ``repository_url`` refers to the GitHub instance that hosts the action you are using. If omitted, the default is assumed to be `https://github.com/`.
 - Examples::

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -262,7 +262,8 @@ githubactions
 - The ``name`` is the repository name. It is not case sensitive and must be
   lowercased.
 - The ``subpath`` is used to point to a secondary action within a repository. It is not case sensitive and must be lowercased.
-- The ``version`` is a commit or release tag. 
+- The ``version`` is a commit SHA or release tag. 
+- The ``repositoryUrl`` refers to the GitHub instance you are using. If omitted, the default is assumed to be `https://github.com/`.
 - Examples::
 
       pkg:githubactions/package-url/purl-spec@244fd47e07d1004

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -263,7 +263,7 @@ githubactions
   lowercased.
 - The ``subpath`` is used to point to a secondary action within a repository. It is not case sensitive and must be lowercased.
 - The ``version`` is a commit SHA or release tag. 
-- The ``repositoryUrl`` refers to the GitHub instance you are using. If omitted, the default is assumed to be `https://github.com/`.
+- The ``repository_url`` refers to the GitHub instance that hosts the action you are using. If omitted, the default is assumed to be `https://github.com/`.
 - Examples::
 
       pkg:githubactions/package-url/purl-spec@244fd47e07d1004


### PR DESCRIPTION
This PR adds GitHub Actions as a distinct type. We use this in the GitHub Dependency graph because GitHub Actions are distinct in meaning from the GitHub repository package references, and sometimes get CVEs published on them. 