### PR TITLE
pypi: change default repository

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -457,7 +457,7 @@ pypi
 ----
 ``pypi`` for Python packages:
 
-- The default repository is ``https://pypi.python.org``.
+- The default repository is ``https://pypi.org``.
 - PyPI treats ``-`` and ``_`` as the same character and is not case sensitive.
   Therefore a PyPI package ``name`` must be lowercased and underscore ``_``
   replaced with a dash ``-``.

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -457,7 +457,7 @@ pypi
 ----
 ``pypi`` for Python packages:
 
-- The default repository is ``https://pypi.org``.
+- The default repository is ``https://pypi.org``. (Previously  ``https://pypi.python.org``.)
 - PyPI treats ``-`` and ``_`` as the same character and is not case sensitive.
   Therefore a PyPI package ``name`` must be lowercased and underscore ``_``
   replaced with a dash ``-``.


### PR DESCRIPTION
`python.pypi.org` is the legacy index domain name and was replaced by `pypi.org` in 2017. See: https://packaging.python.org/en/latest/glossary/#term-pypi.org