### PR TITLE
define handling of plus and space

### DIFF
--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -214,6 +214,10 @@ The rules for each component are:
     - A `value` must be a percent-encoded string
     - The '=' separator is neither part of the `key` nor of the `value`
 
+  - Although this format may seem like `x-www-form-urlencoded`_, it is not.
+    This means that spaces are always encoded as %20, not '+', and '+' is decoded as '+'.
+
+.. _x-www-form-urlencoded: https://url.spec.whatwg.org/#application/x-www-form-urlencoded
 
 - **subpath**:
 
@@ -259,6 +263,9 @@ Use these rules for percent-encoding and decoding `purl` components:
 - the '?' `qualifiers` separator must be encoded as `%3F` elsewhere
 - the '=' `qualifiers` key/value separator must NOT be encoded
 - the '#' `subpath` separator must be encoded as `%23` elsewhere
+
+- the ' ' character must be encoded as `%20` everywhere, never '+'
+- the '+' character should be encoded as `%2B` in qualifiers to avoid problems with certain parsers
 
 - All non-ASCII characters must be encoded as UTF-8 and then percent-encoded
 

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -100,7 +100,7 @@ cocoapods
       pkg:cocoapods/AFNetworking@4.0.1
       pkg:cocoapods/MapsIndoors@3.24.0
       pkg:cocoapods/ShareKit@2.0#Twitter
-      pkg:cocoapods/GoogleUtilities@7.5.2#NSData+zlib
+      pkg:cocoapods/GoogleUtilities@7.5.2#NSData%2Bzlib
 
 cargo
 -----
@@ -504,9 +504,9 @@ Use of known qualifiers key/value pairs such as ``download_url`` can be used to 
 
 - Examples::
 
-      pkg:swid/Acme/example.com/Enterprise+Server@1.0.0?tag_id=75b8c285-fa7b-485b-b199-4745e3004d0d
+      pkg:swid/Acme/example.com/Enterprise%20Server@1.0.0?tag_id=75b8c285-fa7b-485b-b199-4745e3004d0d
       pkg:swid/Fedora@29?tag_id=org.fedoraproject.Fedora-29
-      pkg:swid/Adobe+Systems+Incorporated/Adobe+InDesign@CC?tag_id=CreativeCloud-CS6-Win-GM-MUL
+      pkg:swid/Adobe%20Systems%20Incorporated/Adobe%20InDesign@CC?tag_id=CreativeCloud-CS6-Win-GM-MUL
 
 swift
 -----

--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -567,14 +567,14 @@
   },
   {
     "description": "spaces are spaces",
-    "purl": "pkg:golang/example.com/our examples/example widgets@first draft?x-space= #sub path",
-    "canonical_purl": "pkg:golang/example.com/our%20examples/example%20widgets@first%20draft?x-space=%20#sub%20path",
+    "purl": "pkg:golang/example.com/our examples/example widgets@first draft?x-space=a b#sub path",
+    "canonical_purl": "pkg:golang/example.com/our%20examples/example%20widgets@first%20draft?x-space=a%20b#sub%20path",
     "type": "golang",
     "namespace": "example.com/our examples",
     "name": "example widgets",
     "version": "first draft",
     "qualifiers": {
-      "x-space": " "
+      "x-space": "a b"
     },
     "subpath": "sub path",
     "is_invalid": false

--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -550,5 +550,33 @@
     "qualifiers": null,
     "subpath": null,
     "is_invalid": false
+  },
+  {
+    "description": "plus signs are plus signs",
+    "purl": "pkg:golang/example+.com/widgets+@v1.0.0+5?x-plus=+#a+",
+    "canonical_purl": "pkg:golang/example+.com/widgets+@v1.0.0+5?x-plus=%2B#a+",
+    "type": "golang",
+    "namespace": "example+.com",
+    "name": "widgets+",
+    "version": "v1.0.0+5",
+    "qualifiers": {
+      "x-plus": "+"
+    },
+    "subpath": "a+",
+    "is_invalid": false
+  },
+  {
+    "description": "spaces are spaces",
+    "purl": "pkg:golang/example.com/our examples/example widgets@first draft?x-space= #sub path",
+    "canonical_purl": "pkg:golang/example.com/our%20examples/example%20widgets@first%20draft?x-space=%20#sub%20path",
+    "type": "golang",
+    "namespace": "example.com/our examples",
+    "name": "example widgets",
+    "version": "first draft",
+    "qualifiers": {
+      "x-space": " "
+    },
+    "subpath": "sub path",
+    "is_invalid": false
   }
 ]


### PR DESCRIPTION
This is a big change (in terms of impact, not lines), and I'm not entirely sure its the correct change, but something needs to be done in this area.

# Problem

The PURL spec describes qualifiers as being an `&` delimited sequenced of `=` delimited key value pairs where the value is percent encoded, and the section on encoding describes a minimal set of characters that are supposed to be percent encoded in different contexts. This looks a lot like [x-www-formurlencoded](https://url.spec.whatwg.org/#application/x-www-form-urlencoded), but x-www-formurlencoded encodes almost all characters besides the ascii alphanumeric set, and has a special behavior where ' ' is encoded as '+'.

I am aware of thirteen PURL implementations:

| Implementation | '&nbsp;' decodes as '&nbsp;' | '&nbsp;' encodes as %20 | '+' decodes as '+' | '+' encodes as %2B |
|--------|--------|--------|--------|--------|
| althonos/packageurl.rs | ✅ | ✅ | ✅ | ⚠️ |
| anchore/packageurl-go | ✅ | ✅  | ✅ | ⚠️ implemented in prerelease |
| giterlizzi/perl-URI-PackageURL | ☠️ parses incorrectly | ✅ | ✅ | ✅ |
| maennchen/purl | 💣 does not parse | ⚠️ sometimes encodes as ' ' | ❌ | ☠️ '+' is encoded as '+' which decodes as ' ' |
| package-url/packageurl-dotnet | ✅ | ❌ | ❌ | ✅ |
| package-url/packageurl-go | ✅ | ❌ | ❌ | ✅ |
| package-url/packageurl-java | 💣 does not parse | ✅ | ✅ | ✅ |
| package-url/packageurl-js | ✅ | ✅ | ❌ | ✅ |
| package-url/packageurl-php | ✅ | ✅ | ✅ | ✅ |
| package-url/packageurl-python | ✅ | ✅ | ✅ | ✅ |
| package-url/packageurl-ruby | ✅ | ❌ | ❌ | ✅ |
| package-url/packageurl-swift | ✅ | ✅ | ✅ | ✅ |
| phylum-dev/purl | ✅ | ✅ | ✅ | ✅ |
| sonatype/package-url-java | ✅ | ✅ | ❌ | ☠️ ['+' is sometimes encoded as %20](https://github.com/sonatype/package-url-java/issues/67) |

That means if you're working with qualifiers that have spaces or plus signs in their values, it's fairly likely that software using a different implementation of PURL will interpret the PURLs differently. This may also happen if your PURLs have plus signs in their versions (deb) or spaces in their names (swid) and the implementation incorrectly decodes the name and version as if they were qualifier values (see below).

6/14 of the implementations are decoding '+' as ' ', so here's why I think it's better for the spec to specify '+' is '+':
1. The spec doesn't say it should be x-www-formurlencoded, although it could be argued that it is implied. Using x-www-formurlencoded would make PURLs more compatible with regular URL parsers and utilities (but still not 100% compatible IIRC), at the expensive of making the specification more complicated.
2. Three of those six implementations that encode and decode qualifier values as if they were x-www-formurlencoded also encode and decode other parts of the PURL, such as the version, as if it were an x-www-formurlencoded value. This is not standard URL behavior and it is not part of the PURL spec. This seems like an implementation mistake, incorrect regardless of how the qualifier values are encoded. (package-url/packageurl-dotnet, package-url/packageurl-ruby, sonatype/package-url-java)
3. Having a different encoding scheme for the qualifiers vs the rest of the PURL, while common for regular URLs, can lead to confusion, both for implementors (see above) and for users when dealing with PURLs that contain plus signs in and out of qualifiers.

# Proposal

1. ' ' decodes as ' ' and '+' decodes as '+' (as in 8/14 implementations)
2. In qualifiers, ' ' encodes as %20 and '+' encodes as %2B (as in 8/14 implementations) to avoid ambiguity when PURLs are parsed by implementations pre this change (unfortunately, there's nothing we can do about parsing PURLs created by implementations pre this change)
3. In the rest of the PURL, ' ' encodes as %20 and '+' encodes as '+' because that's how the spec was written, it's not ambiguous that the rest of the PURL might be x-www-formurlencoded, and plus signs seem like they're common enough with some package types that there's benefit in keeping them unencoded.

The spec is updated to be specific, new tests are added to the test suite, and incorrectly escaped examples in the package types spec are updated to be consistent.

Unfortunately, this requires changes to at least 7/14 implementations to get everything aligned, but they should be minor changes.