### PR TITLE
Add new PURL type: 'cos' for Container-Optimized OS

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -166,6 +166,18 @@ conda
 
       pkg:conda/absl-py@0.4.1?build=py36h06a4308_0&channel=main&subdir=linux-64&type=tar.bz2
 
+cos
+-----
+``cos`` for [Container-Optimized OS](http://cloud/container-optimized-os/docs) packages:
+
+- There is no public repository or package manager  for these packages.
+- The ``name`` is the package name.
+- The ``version`` is the package version.
+- Qualifier ``distro``: The OS version in the form ``cos-[OSV_VERSION]``.
+- Examples::
+
+      pkg:cos/python-exec@17162.336.16?distro=cos-101
+
 cran
 -----
 ``cran`` for CRAN R packages:


### PR DESCRIPTION
The [Container-Optimized OS](https://cloud.google.com/container-optimized-os/docs) (COS) is a Google provided operating system that is optimized to run containers. "Container-Optimized OS does not include a package manager; as such, you'll be unable to install software packages directly on an instance" [source](https://cloud.google.com/container-optimized-os/docs/concepts/features-and-benefits#limitations). The pre-installed packages can be found by inspecting `etc/cos-package-info.json`. These packages are maintained by Google. The repository is not publicly accessible, hence no default repository.

Example of what `cos-package-info.json` looks like:
```
{
    "installedPackages": [
        {
            "category": "dev-lang",
            "name": "python-exec",
            "version": "17162.336.16",
            "ebuild_version": "2.0.1-r1"
        },
        ...
    ],
    "buildTimePackages": [
        {
            "category": "app-admin",
            "name": "eselect",
            "version": "17162.336.16",
            "ebuild_version": "1.4.8"
        },
        ...
    ],
}
```

Packages also depend on the COS version which can be found in `etc/os-release` similar to other OSes like Debian, Ubuntu, etc. Hence the inclusion of the `distro` qualifier similar to `deb`'s `distro` qualifier.

It's unclear if `category` or `ebuild_version` should be included in the PURL qualifiers for completeness. And if the PURL should contain info on whether this is an installed or build time package. That doesn't have to be part of the official spec.