### PR TITLE
Add new PURL type: 'p2' for Eclipse packages

### DIFF
--- a/tests/types/p2-test.json
+++ b/tests/types/p2-test.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://packageurl.org/schemas/p2-test-1.0.json",
+  "tests": [
+    {
+      "description": "valid p2 purl",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "p2",
+        "name": "org.eclipse.swt",
+        "version": "3.124.200.v20231113-1355",
+        "qualifiers": {
+          "classifier": "osgi.bundle",
+          "repository_url": "https://download.eclipse.org/releases/2023-12"
+        }
+      },
+      "expected_output": "pkg:p2/org.eclipse.swt@3.124.200.v20231113-1355?classifier=osgi.bundle&repository_url=https://download.eclipse.org/releases/2023-12",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "valid p2 purl (without classifier)",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "p2",
+        "name": "org.eclipse.swt",
+        "version": "3.124.200.v20231113-1355",
+        "qualifiers": {
+          "repository_url": "https://download.eclipse.org/releases/2023-12"
+        }
+      },
+      "expected_output": "pkg:p2/org.eclipse.swt@3.124.200.v20231113-1355?repository_url=https://download.eclipse.org/releases/2023-12",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "invalid p2 purl",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "p2",
+        "name": "org.eclipse.swt",
+        "version": "3.124.200.v20231113-1355",
+        "qualifiers": {
+          "classifier": "osgi.bundle"
+        }
+      },
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "The 'repository_url' qualifier is mandatory"
+    },
+    {
+      "description": "parse valid p2 purl",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:p2/org.eclipse.swt@3.124.200.v20231113-1355?classifier=osgi.bundle&repository_url=https://download.eclipse.org/releases/2023-12",
+      "expected_output": {
+        "type": "p2",
+        "name": "org.eclipse.swt",
+        "version": "3.124.200.v20231113-1355",
+        "qualifiers": {
+          "classifier": "osgi.bundle",
+          "repository_url": "https://download.eclipse.org/releases/2023-12"
+        }
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "parse valid p2 purl (without classifier)",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:p2/org.eclipse.swt@3.124.200.v20231113-1355?repository_url=https://download.eclipse.org/releases/2023-12",
+      "expected_output": {
+        "type": "p2",
+        "name": "org.eclipse.swt",
+        "version": "3.124.200.v20231113-1355",
+        "qualifiers": {
+          "repository_url": "https://download.eclipse.org/releases/2023-12"
+        }
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "parse invalid p2 purl",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:p2/org.eclipse.swt@3.124.200.v20231113-1355?classifier=osgi.bundle",
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "The 'repository_url' qualifier is mandatory"
+    }
+  ]
+}

--- a/types/p2-definition.json
+++ b/types/p2-definition.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
+  "$id": "https://packageurl.org/types/p2-definition.json",
+  "type": "p2",
+  "type_name": "p2",
+  "description": "Installation and updates are managed in Eclipse using a provisioning platform called p2.",
+  "repository": {
+    "use_repository": true,
+    "note": "There is no default package repository; the repository url must be provided as 'repository_url' qualifier key."
+  },
+  "namespace_definition": {
+    "requirement": "prohibited",
+    "note": "There is no namespace"
+  },
+  "name_definition": {
+    "requirement": "required",
+    "case_sensitive": true,
+    "note": "The bundle symbolic-name. See the OSGi specification for a detailed description of the allowed characters: https://docs.osgi.org/specification/osgi.core/8.0.0/framework.introduction.html#framework.general.syntax"
+  },
+  "qualifiers_definition": [
+    {
+      "key": "repository_url",
+      "requirement": "required",
+      "description": "URL for the repository, the artifact is located at."
+    },
+    {
+      "key": "classifier",
+      "requirement": "optional",
+      "description": "The artifact type. e.g. 'osgi.bundle'."
+    }
+  ],
+  "examples": [
+    "pkg:p2/org.eclipse.swt@3.124.200.v20231113-1355?classifier=osgi.bundle&repository_url=https://download.eclipse.org/releases/2023-12"
+  ]
+}


### PR DESCRIPTION
An initial draft for bundles and features. There are more p2 types, but I can't see any use case where it would be necessary to explicitly specify them. 
#271 