### PR TITLE
Add spec for `brew` package URLs

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -87,6 +87,25 @@ bitnami
       pkg:bitnami/wordpress@6.2.0
       pkg:bitnami/wordpress@6.2.0?arch=arm64
 
+brew
+----
+``brew`` for Homebrew-based packages:
+
+- The default repository (tap) is ``homebrew/core``.
+
+  - The tap syntax is ``https://github.com/{org}/Homebrew-{tap}``, so
+    ``homebrew/core`` corresponds to the URL ``https://github.com/homebrew/homebrew-core``.
+- The ``name`` is the formula name.
+- The ``version`` is the formula version.
+- Qualifier ``tap_url``: for taps that are not on GitHub or otherwise require an explicit URL,
+  this is the full URL to the tap.
+- Examples::
+
+      pkg:brew/sqlite@3.43.2
+      pkg:brew/homebrew/core/sqlite@3.43.2
+      pkg:brew/some-org/some-tap/some-app@1.2.3
+      pkg:brew/some-org/some-tap/some-app@1.2.3&tap_url=https://git.example.com/some-org/some-tap.git
+
 cocoapods
 ---------
 ``cocoapods`` for CocoaPods:

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -91,10 +91,10 @@ brew
 ----
 ``brew`` for Homebrew-based packages:
 
-- The default repository (tap) is ``homebrew/core``.
+- The default repository, which is called a "Tap" in Homebrew terminology, is ``homebrew/core``.
 
-  - The tap syntax is ``https://github.com/{org}/Homebrew-{tap}``, so
-    ``homebrew/core`` corresponds to the URL ``https://github.com/homebrew/homebrew-core``.
+  - The typical tap identifier expands to the URL ``https://github.com/{org}/Homebrew-{tap}``, so the tap identifier
+    ``homebrew/core`` corresponds to the tap URL ``https://github.com/homebrew/homebrew-core``.
 - The ``name`` is the formula name.
 - The ``version`` is the formula version.
 - Qualifier ``tap_url``: for taps that are not on GitHub or otherwise require an explicit URL,
@@ -104,7 +104,7 @@ brew
       pkg:brew/sqlite@3.43.2
       pkg:brew/homebrew/core/sqlite@3.43.2
       pkg:brew/some-org/some-tap/some-app@1.2.3
-      pkg:brew/some-org/some-tap/some-app@1.2.3&tap_url=https://git.example.com/some-org/some-tap.git
+      pkg:brew/some-org/some-tap/some-app@1.2.3?tap_url=https://git.example.com/some-org/some-tap.git
 
 cocoapods
 ---------

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -554,7 +554,6 @@ Other candidate types to define:
 - ``android`` for Android apk packages:
 - ``atom`` for Atom packages:
 - ``bower`` for Bower JavaScript packages:
-- ``brew`` for Homebrew packages:
 - ``buildroot`` for Buildroot packages
 - ``carthage`` for Cocoapods Cocoa packages:
 - ``chef`` for Chef packages:

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -95,6 +95,7 @@ brew
 
   - The typical tap identifier expands to the URL ``https://github.com/{org}/Homebrew-{tap}``, so the tap identifier
     ``homebrew/core`` corresponds to the tap URL ``https://github.com/homebrew/homebrew-core``.
+  - Any git URL is a valid tap URL (see ``tap_url``)
 - The ``name`` is the formula name.
 - The ``version`` is the formula version.
 - Qualifier ``tap_url``: for taps that are not on GitHub or otherwise require an explicit URL,

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -93,9 +93,11 @@ brew
 
 - The default repository, which is called a "Tap" in Homebrew terminology, is ``homebrew/core``.
 
-  - The typical tap identifier expands to the URL ``https://github.com/{org}/Homebrew-{tap}``, so the tap identifier
-    ``homebrew/core`` corresponds to the tap URL ``https://github.com/homebrew/homebrew-core``.
+  - The typical tap identifier expands to the URL ``https://github.com/{org}/Homebrew-{tap}``, so
+    the tap identifier ``homebrew/core`` corresponds to the tap URL
+    ``https://github.com/homebrew/homebrew-core``.
   - Any git URL is a valid tap URL (see ``tap_url``)
+
 - The ``name`` is the formula name.
 - The ``version`` is the formula version.
 - Qualifier ``tap_url``: for taps that are not on GitHub or otherwise require an explicit URL,

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -105,6 +105,7 @@ brew
 - Examples::
 
       pkg:brew/sqlite@3.43.2
+      pkg:brew/postgresql%4012@12.17
       pkg:brew/homebrew/core/sqlite@3.43.2
       pkg:brew/some-org/some-tap/some-app@1.2.3
       pkg:brew/some-org/some-tap/some-app@1.2.3?tap_url=https://git.example.com/some-org/some-tap.git

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -91,17 +91,20 @@ brew
 ----
 ``brew`` for Homebrew-based packages:
 
-- The default repository, which is called a "Tap" in Homebrew terminology, is ``homebrew/core``.
+- There is no default package repository; this should be implied either from
+  the ``namespace`` or using a tap URL via the ``tap_url`` qualifier.
+- The ``namespace``, which is called a "Tap" in Homebrew terminology, defaults to ``homebrew/core``.
 
-  - The typical tap identifier expands to the URL ``https://github.com/{org}/Homebrew-{tap}``, so
-    the tap identifier ``homebrew/core`` corresponds to the tap URL
-    ``https://github.com/homebrew/homebrew-core``.
-  - Any git URL is a valid tap URL (see ``tap_url``)
+  - When the ``tap_url`` qualifier is not specified, the Tap identifier corresponds to the URL
+    ``https://github.com/{org}/homebrew-{tap}``, such as
+    ``https://github.com/homebrew/homebrew-core`` for ``homebrew/core``.
+  - When the ``tap_url`` qualifier is specified, the Tap identifier is the local name of the Tap.
 
-- The ``name`` is the formula name.
+- The ``name`` is the formula name. Formula names that contain ``@`` must be percent-encoded,
+  such as ``postgresql%4012`` for ``postgres@12``.
 - The ``version`` is the formula version.
 - Qualifier ``tap_url``: for taps that are not on GitHub or otherwise require an explicit URL,
-  this is the full URL to the tap.
+  this is the full ``git`` URL to the tap.
 - Examples::
 
       pkg:brew/sqlite@3.43.2

--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -580,7 +580,7 @@
     "purl": "pkg:brew/some-org/some-tap/sqlite@3.43.2?tap_url=https://git.example.com/some-org/some-tap.git",
     "canonical_purl": "pkg:brew/some-org/some-tap/sqlite@3.43.2?tap_url=https://git.example.com/some-org/some-tap.git",
     "type": "brew",
-    "namespace": "https://git.example.com/some-org/some-tap.git",
+    "namespace": "some-org/some-tap",
     "name": "sqlite",
     "version": "3.43.2",
     "qualifiers": { "tap_url": "https://git.example.com/some-org/some-tap.git"},


### PR DESCRIPTION
This adds the `brew` purl type.

Closes #254.