### PR TITLE
apk: define `arch=source` qualifier

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -53,7 +53,8 @@ apk
 - The ``name`` is the package name. It is not case sensitive and must be
   lowercased.
 - The ``version`` is a package version as expected by apk.
-- The ``arch`` is the qualifiers key for a package architecture.
+- The ``arch`` is the qualifiers key for a package architecture. The special value
+  ``arch=source`` identifies an Alpine source package as built by ``abuild srcpkg``.
 - Examples::
 
       pkg:apk/alpine/curl@7.83.0-r0?arch=x86


### PR DESCRIPTION
This proposes a similar approach for Alpine to what we agreed on for Debian in #57. 

Thanks for reviewing, let me know what you think and if you need an additional issue for it!


