### PR TITLE
Fix link to "Type definitions" to PURL-TYPES.rst

### DIFF
--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -14,8 +14,8 @@ packaging conventions, tools, APIs and databases.
 Such a package URL is useful to reliably reference the same software package
 using a simple and expressive syntax and conventions based on familiar URLs.
 
-See https://github.com/package-url/purl-spec for the Package URL specification
-and `<PURL-SPECIFICATION.rst>`_ for known type definitions.
+See also https://github.com/package-url/purl-spec and
+and `<PURL-TYPES.rst>`_ for known type definitions.
 
 Check also this short `purl` presentation (with video) at FOSDEM 2018
 https://fosdem.org/2018/schedule/event/purl/ for an overview.

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -14,8 +14,7 @@ packaging conventions, tools, APIs and databases.
 Such a package URL is useful to reliably reference the same software package
 using a simple and expressive syntax and conventions based on familiar URLs.
 
-See https://github.com/package-url/purl-spec for the Package URL specification
-and `<PURL-TYPES.rst>`_ for known type definitions.
+See <PURL-TYPES.rst>_ for known type definitions.
 
 Check also this short ``purl`` presentation (with video) at FOSDEM 2018
 https://fosdem.org/2018/schedule/event/purl/ for an overview.

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -14,7 +14,7 @@ packaging conventions, tools, APIs and databases.
 Such a package URL is useful to reliably reference the same software package
 using a simple and expressive syntax and conventions based on familiar URLs.
 
-See also https://github.com/package-url/purl-spec
+See https://github.com/package-url/purl-spec for the Package URL specification
 and `<PURL-TYPES.rst>`_ for known type definitions.
 
 Check also this short `purl` presentation (with video) at FOSDEM 2018

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -14,7 +14,7 @@ packaging conventions, tools, APIs and databases.
 Such a package URL is useful to reliably reference the same software package
 using a simple and expressive syntax and conventions based on familiar URLs.
 
-See also https://github.com/package-url/purl-spec and
+See also https://github.com/package-url/purl-spec
 and `<PURL-TYPES.rst>`_ for known type definitions.
 
 Check also this short `purl` presentation (with video) at FOSDEM 2018


### PR DESCRIPTION
Currently, the text in `PURL-SPECIFICATION.rst` said:

> See https://github.com/package-url/purl-spec for the Package URL specification
> and `<PURL-SPECIFICATION.rst>`_ for known type definitions.

which is self-reference and also not correct.

- `PURL-SPECIFICATION.rst` is the core spec.
- Type definitions are in `PURL-TYPES.rst`

Proposed text:

>  See https://github.com/package-url/purl-spec for the Package URL specification
> and `<PURL-TYPES.rst>`_ for known type definitions.