### PR TITLE
Add `bazel` type for Bazel modules

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -59,6 +59,24 @@ apk
       pkg:apk/alpine/curl@7.83.0-r0?arch=x86
       pkg:apk/alpine/apk@2.12.9-r3?arch=x86
 
+bazel
+-----
+``bazel`` for Bazel modules:
+
+- The default repository ("registry") is ``https://bcr.bazel.build``, the
+  Bazel Central Registry (BCR).
+- The ``namespace``, if specified, is the host and path of the URL of an
+  alternative registry. It is not case sensitive and must be lowercased.
+- The ``name`` is the module name. It is case sensitive, but a single registry
+  will never contain two different module names that compare equal
+  case-insensitively.
+- The ``version`` is the module version.
+- Examples::
+
+      pkg:bazel/rules_java@7.8.0
+      pkg:bazel/curl@8.8.0.bcr.1
+      pkg:bazel/example.org/bazel-registry/curl@8.8.0
+
 bitbucket
 ---------
 ``bitbucket`` for Bitbucket-based packages:

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -65,17 +65,23 @@ bazel
 
 - The default repository ("registry") is ``https://bcr.bazel.build``, the
   Bazel Central Registry (BCR).
-- The ``namespace``, if specified, is the host and path of the URL of an
-  alternative registry. It is not case sensitive and must be lowercased.
 - The ``name`` is the module name. It is case sensitive, but a single registry
   will never contain two different module names that compare equal
   case-insensitively.
-- The ``version`` is the module version.
+- The ``version`` is the module version in `Bazel's relaxed semver format
+  <https://bazel.build/external/module#version_format>`_.
+- The optional ``repository_url`` can be used to specify the URL of an
+  alternative registry.
+- The optional ``subpath`` can name a particular Bazel target in the module via
+  a label with the leading double slash (``//``) removed and canonicalized by
+  omitting the target name if it is equal to the name of the containing package. 
 - Examples::
 
       pkg:bazel/rules_java@7.8.0
       pkg:bazel/curl@8.8.0.bcr.1
-      pkg:bazel/example.org/bazel-registry/curl@8.8.0
+      pkg:bazel/curl@8.8.0?repository_url=https://example.org/bazel-registry
+      pkg:bazel/rules_java@7.8.0
+      pkg:bazel/rules_java@7.8.0#toolchains:singlejar
 
 bitbucket
 ---------

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -65,16 +65,14 @@ bazel
 
 - The default repository ("registry") is ``https://bcr.bazel.build``, the
   Bazel Central Registry (BCR).
-- The ``name`` is the module name. It is case sensitive, but a single registry
-  will never contain two different module names that compare equal
-  case-insensitively.
+- The ``name`` is the module name. It must be lowercased.
 - The ``version`` is the module version in `Bazel's relaxed semver format
   <https://bazel.build/external/module#version_format>`_.
 - The optional ``repository_url`` can be used to specify the URL of an
-  alternative registry.
+  alternative registry, with any trailing forward slashes removed.
 - The optional ``subpath`` can name a particular Bazel target in the module via
   a label with the leading double slash (``//``) removed and canonicalized by
-  omitting the target name if it is equal to the name of the containing package. 
+  omitting the target name if it is equal to the name of the containing package.
 - Examples::
 
       pkg:bazel/rules_java@7.8.0

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -82,6 +82,7 @@ bazel
       pkg:bazel/curl@8.8.0?repository_url=https://example.org/bazel-registry
       pkg:bazel/rules_java@7.8.0
       pkg:bazel/rules_java@7.8.0#toolchains:singlejar
+      pkg:bazel/rules_go@0.48.0#go
 
 bitbucket
 ---------

--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -550,5 +550,89 @@
     "qualifiers": null,
     "subpath": null,
     "is_invalid": false
+  },
+  {
+    "description": "bazel module with default registry",
+    "purl": "pkg:bazel/rules_java@7.8.0?registry_url=https://bcr.bazel.build/",
+    "canonical_purl": "pkg:bazel/rules_java@7.8.0",
+    "type": "bazel",
+    "namespace": null,
+    "name": "rules_java",
+    "version": "7.8.0",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "bazel module with custom registry",
+    "purl": "pkg:bazel/rules_java@7.8.0?registry_url=https://example.org/bazel-registry/",
+    "canonical_purl": "pkg:bazel/rules_java@7.8.0?registry_url=https://example.org/bazel-registry",
+    "type": "bazel",
+    "namespace": null,
+    "name": "rules_java",
+    "version": "7.8.0",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "bazel module with relaxed semver version",
+    "purl": "pkg:bazel/curl@8.8.0.bcr.1",
+    "canonical_purl": "pkg:bazel/curl@8.8.0.bcr.1",
+    "type": "bazel",
+    "namespace": null,
+    "name": "curl",
+    "version": "8.8.0.bcr.1",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "bazel module names are lowercased",
+    "purl": "pkg:bazel/Curl@8.8.0.bcr.1",
+    "canonical_purl": "pkg:bazel/Curl@8.8.0.bcr.1",
+    "type": "bazel",
+    "namespace": null,
+    "name": "curl",
+    "version": "8.8.0.bcr.1",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": true
+  },
+  {
+    "description": "bazel module with target",
+    "purl": "pkg:bazel/rules_java@7.8.0#//toolchains:singlejar",
+    "canonical_purl": "pkg:bazel/rules_java@7.8.0#toolchains:singlejar",
+    "type": "bazel",
+    "namespace": null,
+    "name": "rules_java",
+    "version": "7.8.0",
+    "qualifiers": null,
+    "subpath": "toolchains:singlejar",
+    "is_invalid": false
+  },
+  {
+    "description": "bazel module with target in short-hand form",
+    "purl": "pkg:bazel/rules_go@0.48.0#//go:go",
+    "canonical_purl": "pkg:bazel/rules_go@0.48.0#go",
+    "type": "bazel",
+    "namespace": null,
+    "name": "rules_go",
+    "version": "0.48.0",
+    "qualifiers": null,
+    "subpath": "go",
+    "is_invalid": false
+  },
+  {
+    "description": "bazel module with top-level target",
+    "purl": "pkg:bazel/rules_go@0.48.0#//:stdlib",
+    "canonical_purl": "pkg:bazel/rules_go@0.48.0#:stdlib",
+    "type": "bazel",
+    "namespace": null,
+    "name": "rules_go",
+    "version": "0.48.0",
+    "qualifiers": null,
+    "subpath": ":stdlib",
+    "is_invalid": false
   }
 ]


### PR DESCRIPTION
Bazel 6 introduced a new system for managing external dependencies centered around the concept of [Bazel modules](https://bazel.build/external/module), which are hosted in a [registry](https://bazel.build/external/registry). The default registry is the [Bazel Central Registry](https://bcr.bazel.build). This system will become the default this year and its predecessor will be turned off next year.

As discussed in https://github.com/bazelbuild/bazel/discussions/23166, we would thus like to register the `bazel` purl type for Bazel modules, as specified in this PR.

(currently waiting for feedback from the [Rules Authors SIG](https://github.com/bazel-contrib/SIG-rules-authors))
