### PR TITLE
Add new PURL type:  'mendix'

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -607,6 +607,7 @@ Other candidate types to define:
 - ``helm`` for Kubernetes packages
 - ``julia`` for Julia packages:
 - ``melpa`` for Emacs packages
+- ``mendix`` for Mendix packages
 - ``meteor`` for Meteor JavaScript packages:
 - ``nim`` for Nim packages:
 - ``nix`` for Nixos packages:


### PR DESCRIPTION
Please consider adding the package type we use in our SBOM to be added to the list of known types.

The Mendix platform is a low-code platform with its own package system. Mendix packages are imported into Mendix Apps, or used as IDE extensions and hosted on the Mendix Marketplace , see https://marketplace.mendix.com/. A SBOM is created for the App which used package urls to list the components in the App.

We will add more details about the other elements like qualifiers that we use at a later point.