### PR TITLE
Added CPAN tests and FIX typos in PURL-SPEC

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -174,7 +174,7 @@ cpan
 
 - The default repository is ``https://www.cpan.org/``.
 - The ``namespace``:
-  - To refer to a CPAN distribution name, the ``namespace`` MUST be present. In this case, the namespace is the CPAN id of the author/publisher. It MUST be written uppercase, followed by the distribution name in the ``name`` component. A distribution name may NEVER contain the string ``::``.
+  - To refer to a CPAN distribution name, the ``namespace`` MUST be present. In this case, the namespace is the CPAN id of the author/publisher. It MUST be written uppercase, followed by the distribution name in the ``name`` component. A distribution name MUST NOT contain the string ``::``.
   - To refer to a CPAN module, the ``namespace`` MUST be absent. The module name MAY contain zero or more ``::`` strings, and the module name MUST NOT contain a ``-``
 
 - The ``name`` is the module or distribution name and is case sensitive.

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -172,7 +172,7 @@ cpan
 ----
 ``cpan`` for CPAN Perl packages:
 
-- The default respository is ``https://www.cpan.org/``.
+- The default repository is ``https://www.cpan.org/``.
 - The ``namespace``:
   - To refer to a CPAN distribution name, the ``namespace`` MUST be present. In this case, the namespace is the CPAN id of the author/publisher. It MUST be written uppercase, followed by the distribution name in the ``name`` component. A distribution name may NEVER contain the string ``::``.
   - To refer to a CPAN module, the ``namespace`` MUST be absent. The module name MAY contain zero or more ``::`` strings, and the module name MUST NOT contain a ``-``
@@ -182,7 +182,7 @@ cpan
 - Optional qualifiers may include:
 
   - ``repository_url``: CPAN/MetaCPAN/BackPAN/DarkPAN repository base URL (default is ``https://www.cpan.org``)
-  - ``download_url``: URL of package or distibution
+  - ``download_url``: URL of package or distribution
   - ``vcs_url``: extra URL for a package version control system
   - ``ext``: file extension (default is ``tar.gz``)
 
@@ -374,7 +374,7 @@ luarocks
   The full version number is required to uniquely identify a version.
 - Qualifier ``repository_url``: The LuaRocks rocks server to be used;
   useful in case a private server is used (optional).
-  If ommitted, ``https://luarocks.org`` as default server is assumed.
+  If omitted, ``https://luarocks.org`` as default server is assumed.
 
 Examples::
 

--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -550,5 +550,77 @@
     "qualifiers": null,
     "subpath": null,
     "is_invalid": false
+  },
+  {
+    "description": "cpan distribution name are case sensitive",
+    "purl": "pkg:cpan/DROLSKY/DateTime@1.55",
+    "canonical_purl": "pkg:cpan/DROLSKY/DateTime@1.55",
+    "type": "cpan",
+    "namespace": "DROLSKY",
+    "name": "DateTime",
+    "version": "1.55",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "cpan module name are case sensitive",
+    "purl": "pkg:cpan/URI::PackageURL@2.11",
+    "canonical_purl": "pkg:cpan/URI::PackageURL@2.11",
+    "type": "cpan",
+    "namespace": null,
+    "name": "URI::PackageURL",
+    "version": "2.11",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "cpan module name like distribution name",
+    "purl": "pkg:cpan/Perl-Version@1.013",
+    "canonical_purl": "pkg:cpan/Perl-Version@1.013",
+    "type": "cpan",
+    "namespace": null,
+    "name": "Perl-Version",
+    "version": "1.013",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": true
+  },
+  {
+    "description": "cpan distribution name like module name",
+    "purl": "pkg:cpan/GDT/URI::PackageURL@2.11",
+    "canonical_purl": "pkg:cpan/GDT/URI::PackageURL",
+    "type": "cpan",
+    "namespace": "GDT",
+    "name": "URI::PackageURL",
+    "version": null,
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": true
+  },
+  {
+    "description": "cpan valid module name",
+    "purl": "pkg:cpan/DateTime@1.55",
+    "canonical_purl": "pkg:cpan/DateTime@1.55",
+    "type": "cpan",
+    "namespace": null,
+    "name": "DateTime",
+    "version": "1.55",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "cpan valid module name without version",
+    "purl": "pkg:cpan/URI",
+    "canonical_purl": "pkg:cpan/URI",
+    "type": "cpan",
+    "namespace": null,
+    "name": "URI",
+    "version": null,
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
   }
 ]


### PR DESCRIPTION
This PR add the new tests in `test-suite-data.json` for CPAN type and FIX typo in CPAN and Lua types.

fixes #324