### PR TITLE
Add new spec for `go` package URLs

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -297,6 +297,22 @@ github
       pkg:github/package-url/purl-spec@244fd47e07d1004
       pkg:github/package-url/purl-spec@244fd47e07d1004#everybody/loves/dogs
 
+go
+------
+``go`` for Go modules:
+
+- The ``namespace`` field is empty and implies the go mod proxy.
+- The ``name`` will be the full module path.
+- The ``subpath`` will represent the package path within a module.
+- The ``version`` will be a valid go version or pseudoversion, or empty.
+- Additional Build information for binaries can be included as ``qualifiers`` (i.e VCS info, go version info, GoArch/GoOS info etc)
+- Examples::
+
+      pkg:go/google.golang.org%2Fgenproto#googleapis/api/annotations
+      pkg:go/github.com%2Fjmorion%2Fsqlx@v1.1.2#api
+      pkg:go/golang.org%2Fx%2Fvuln?goversion=1.23.2&vcs=git&vcs_modified=true#cmd/govulncheck
+      pkg:go/golang.org%2Fx%2Fvuln@v1.1.3?goversion=1.23.2#cmd/govulncheck
+
 golang
 ------
 ``golang`` for Go packages:


### PR DESCRIPTION
The current PURL specification for Go was created before Go 1.11 modules and thus has namespace inconsistencies and lacks semantic versioning.

Although in many cases a module path corresponds directly to the URL of the hosting repository, that is not always true. The URL formed from the module path may be an endpoint that serves a redirect to the true host. This indirection protects projects that for whatever reason must change their hosting provider: their module names will continue to work. Consequently, it is undesirable to encode any aspect of the underlying hosting system as part of the PURL.

In essence, all Go modules form a single namespace. Since it is used by the majority of Go programmers, we propose to represent this namespace by the empty string. Though not included in this commit, other namespaces could be possible and would represent package managers and/or build tools that are alternatives to the go command.

The `go` type proposed here fixes the current issues by removing the namespace, using valid Go module versions (including pseudoversions), and adds some extra functionality to encode optional information about specific builds (GOOS, GOARCH, etc).

If accepted, all tools maintained by the Go project (such as govulncheck and [pkg.go.dev](http://pkg.go.dev/)) that surface PURLs will use this new type to provide canonical PURLs for Go modules and packages