### PR TITLE
Fix typos, casing, Rubygems -> RubyGems, etc

### DIFF
--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -411,7 +411,7 @@ To parse a ``purl`` string in its components:
 
   - Discard any empty segment from that split
   - Percent-decode each segment
-  - UTF-8-decode the each segment if needed in your programming
+  - UTF-8-decode each segment if needed in your programming
     language
   - Apply type-specific normalization to each segment if needed
   - Join segments back with a '/'

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -411,8 +411,7 @@ To parse a ``purl`` string in its components:
 
   - Discard any empty segment from that split
   - Percent-decode each segment
-  - UTF-8-decode each segment if needed in your programming
-    language
+  - UTF-8-decode each segment if needed in your programming language
   - Apply type-specific normalization to each segment if needed
   - Join segments back with a '/'
   - This is the ``namespace``

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -104,7 +104,7 @@ A ``purl`` is a URL
 - Version control system (VCS) URLs such ``git://``, ``svn://``, ``hg://`` or as
   defined in Python pip or SPDX download locations are NOT valid ``purl`` types.
   They are valid URL or URI schemes but they are not ``purl``.
-  They are a closely related, compact and uniform way to reference vcs URLs.
+  They are a closely related, compact and uniform way to reference VCS URLs.
   They may be used as references in separate attributes outside of a ``purl`` or
   in a ``purl`` qualifier.
 
@@ -150,7 +150,7 @@ The rules for each component are:
   - The package ``type`` is composed only of ASCII letters and numbers, '.', '+'
     and '-' (period, plus, and dash)
   - The ``type`` cannot start with a number
-  - The ``type`` cannot contains spaces
+  - The ``type`` cannot contain spaces
   - The ``type`` must NOT be percent-encoded
   - The ``type`` is case insensitive. The canonical form is lowercase
 
@@ -209,7 +209,7 @@ The rules for each component are:
     - A ``key`` cannot start with a number
     - A ``key`` must NOT be percent-encoded
     - A ``key`` is case insensitive. The canonical form is lowercase
-    - A ``key`` cannot contains spaces
+    - A ``key`` cannot contain spaces
     - A ``value`` must be a percent-encoded string
     - The '=' separator is neither part of the ``key`` nor of the ``value``
 
@@ -281,7 +281,7 @@ To build a ``purl`` string from its components:
 
 - Start a ``purl`` string with the "pkg:" ``scheme`` as a lowercase ASCII string
 
-- Append the ``type`` string  to the ``purl`` as a lowercase ASCII string
+- Append the ``type`` string to the ``purl`` as a lowercase ASCII string
 
   - Append '/' to the ``purl``
 
@@ -318,15 +318,15 @@ To build a ``purl`` string from its components:
   - Append '?' to the ``purl``
   - Build a list from all key/value pair:
 
-    - discard any pair where the ``value`` is empty.
+    - Discard any pair where the ``value`` is empty.
     - UTF-8-encode each ``value`` if needed in your programming language
     - If the ``key`` is ``checksums`` and this is a list of ``checksums`` join this
       list with a ',' to create this qualifier ``value``
-    - create a string by joining the lowercased ``key``, the equal '=' sign and
+    - Create a string by joining the lowercased ``key``, the equal '=' sign and
       the percent-encoded ``value`` to create a qualifier
 
-  - sort this list of qualifier strings lexicographically
-  - join this list of qualifier strings with a '&' ampersand
+  - Sort this list of qualifier strings lexicographically
+  - Join this list of qualifier strings with a '&' ampersand
   - Append this string to the ``purl``
 
 - If the ``subpath`` is not empty and not composed only of empty, '.' and '..'
@@ -359,7 +359,7 @@ To parse a ``purl`` string in its components:
   - Strip the right side from leading and trailing '/'
   - Split this on '/'
   - Discard any empty string segment from that split
-  - Discard any '.' or  '..' segment from that split
+  - Discard any '.' or '..' segment from that split
   - Percent-decode each segment
   - UTF-8-decode each segment if needed in your programming language
   - Join segments back with a '/'
@@ -433,14 +433,14 @@ identification to ensure that a ``purl`` stays compact and readable in most case
 
 Additional, separate external attributes stored outside of a ``purl`` are the
 preferred mechanism to convey extra long and optional information such as a
-download URL, vcs URL or checksums in an API, database or web form.
+download URL, VCS URL or checksums in an API, database or web form.
 
 
 With this warning, the known ``key`` and ``value`` defined here are valid for use in
 all package types:
 
 - ``repository_url`` is an extra URL for an alternative, non-default package
-  repository or registry.  When a package does not come from the default public
+  repository or registry. When a package does not come from the default public
   package repository for its ``type`` a ``purl`` may be qualified with this extra
   URL. The default repository or registry of a ``type`` is documented in the
   "Known ``purl`` types" section.

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -104,7 +104,7 @@ A ``purl`` is a URL
 - Version control system (VCS) URLs such ``git://``, ``svn://``, ``hg://`` or as
   defined in Python pip or SPDX download locations are NOT valid ``purl`` types.
   They are valid URL or URI schemes but they are not ``purl``.
-  They are a closely related, compact and uniform way to reference vcs URLs.
+  They are a closely related, compact and uniform way to reference VCS URLs.
   They may be used as references in separate attributes outside of a ``purl`` or
   in a ``purl`` qualifier.
 
@@ -150,7 +150,7 @@ The rules for each component are:
   - The package ``type`` is composed only of ASCII letters and numbers, '.', '+'
     and '-' (period, plus, and dash)
   - The ``type`` cannot start with a number
-  - The ``type`` cannot contains spaces
+  - The ``type`` cannot contain spaces
   - The ``type`` must NOT be percent-encoded
   - The ``type`` is case insensitive. The canonical form is lowercase
 
@@ -209,7 +209,7 @@ The rules for each component are:
     - A ``key`` cannot start with a number
     - A ``key`` must NOT be percent-encoded
     - A ``key`` is case insensitive. The canonical form is lowercase
-    - A ``key`` cannot contains spaces
+    - A ``key`` cannot contain spaces
     - A ``value`` must be a percent-encoded string
     - The '=' separator is neither part of the ``key`` nor of the ``value``
 
@@ -281,7 +281,7 @@ To build a ``purl`` string from its components:
 
 - Start a ``purl`` string with the "pkg:" ``scheme`` as a lowercase ASCII string
 
-- Append the ``type`` string  to the ``purl`` as a lowercase ASCII string
+- Append the ``type`` string to the ``purl`` as a lowercase ASCII string
 
   - Append '/' to the ``purl``
 
@@ -318,15 +318,15 @@ To build a ``purl`` string from its components:
   - Append '?' to the ``purl``
   - Build a list from all key/value pair:
 
-    - discard any pair where the ``value`` is empty.
+    - Discard any pair where the ``value`` is empty.
     - UTF-8-encode each ``value`` if needed in your programming language
     - If the ``key`` is ``checksums`` and this is a list of ``checksums`` join this
       list with a ',' to create this qualifier ``value``
-    - create a string by joining the lowercased ``key``, the equal '=' sign and
+    - Create a string by joining the lowercased ``key``, the equal '=' sign and
       the percent-encoded ``value`` to create a qualifier
 
-  - sort this list of qualifier strings lexicographically
-  - join this list of qualifier strings with a '&' ampersand
+  - Sort this list of qualifier strings lexicographically
+  - Join this list of qualifier strings with a '&' ampersand
   - Append this string to the ``purl``
 
 - If the ``subpath`` is not empty and not composed only of empty, '.' and '..'
@@ -359,7 +359,7 @@ To parse a ``purl`` string in its components:
   - Strip the right side from leading and trailing '/'
   - Split this on '/'
   - Discard any empty string segment from that split
-  - Discard any '.' or  '..' segment from that split
+  - Discard any '.' or '..' segment from that split
   - Percent-decode each segment
   - UTF-8-decode each segment if needed in your programming language
   - Join segments back with a '/'
@@ -411,7 +411,7 @@ To parse a ``purl`` string in its components:
 
   - Discard any empty segment from that split
   - Percent-decode each segment
-  - UTF-8-decode the each segment if needed in your programming
+  - UTF-8-decode each segment if needed in your programming
     language
   - Apply type-specific normalization to each segment if needed
   - Join segments back with a '/'
@@ -433,7 +433,7 @@ identification to ensure that a ``purl`` stays compact and readable in most case
 
 Additional, separate external attributes stored outside of a ``purl`` are the
 preferred mechanism to convey extra long and optional information such as a
-download URL, vcs URL or checksums in an API, database or web form.
+download URL, VCS URL or checksums in an API, database or web form.
 
 
 With this warning, the known ``key`` and ``value`` defined here are valid for use in

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -104,7 +104,7 @@ A ``purl`` is a URL
 - Version control system (VCS) URLs such ``git://``, ``svn://``, ``hg://`` or as
   defined in Python pip or SPDX download locations are NOT valid ``purl`` types.
   They are valid URL or URI schemes but they are not ``purl``.
-  They are a closely related, compact and uniform way to reference VCS URLs.
+  They are a closely related, compact and uniform way to reference vcs URLs.
   They may be used as references in separate attributes outside of a ``purl`` or
   in a ``purl`` qualifier.
 
@@ -150,7 +150,7 @@ The rules for each component are:
   - The package ``type`` is composed only of ASCII letters and numbers, '.', '+'
     and '-' (period, plus, and dash)
   - The ``type`` cannot start with a number
-  - The ``type`` cannot contain spaces
+  - The ``type`` cannot contains spaces
   - The ``type`` must NOT be percent-encoded
   - The ``type`` is case insensitive. The canonical form is lowercase
 
@@ -209,7 +209,7 @@ The rules for each component are:
     - A ``key`` cannot start with a number
     - A ``key`` must NOT be percent-encoded
     - A ``key`` is case insensitive. The canonical form is lowercase
-    - A ``key`` cannot contain spaces
+    - A ``key`` cannot contains spaces
     - A ``value`` must be a percent-encoded string
     - The '=' separator is neither part of the ``key`` nor of the ``value``
 
@@ -281,7 +281,7 @@ To build a ``purl`` string from its components:
 
 - Start a ``purl`` string with the "pkg:" ``scheme`` as a lowercase ASCII string
 
-- Append the ``type`` string to the ``purl`` as a lowercase ASCII string
+- Append the ``type`` string  to the ``purl`` as a lowercase ASCII string
 
   - Append '/' to the ``purl``
 
@@ -318,15 +318,15 @@ To build a ``purl`` string from its components:
   - Append '?' to the ``purl``
   - Build a list from all key/value pair:
 
-    - Discard any pair where the ``value`` is empty.
+    - discard any pair where the ``value`` is empty.
     - UTF-8-encode each ``value`` if needed in your programming language
     - If the ``key`` is ``checksums`` and this is a list of ``checksums`` join this
       list with a ',' to create this qualifier ``value``
-    - Create a string by joining the lowercased ``key``, the equal '=' sign and
+    - create a string by joining the lowercased ``key``, the equal '=' sign and
       the percent-encoded ``value`` to create a qualifier
 
-  - Sort this list of qualifier strings lexicographically
-  - Join this list of qualifier strings with a '&' ampersand
+  - sort this list of qualifier strings lexicographically
+  - join this list of qualifier strings with a '&' ampersand
   - Append this string to the ``purl``
 
 - If the ``subpath`` is not empty and not composed only of empty, '.' and '..'
@@ -359,7 +359,7 @@ To parse a ``purl`` string in its components:
   - Strip the right side from leading and trailing '/'
   - Split this on '/'
   - Discard any empty string segment from that split
-  - Discard any '.' or '..' segment from that split
+  - Discard any '.' or  '..' segment from that split
   - Percent-decode each segment
   - UTF-8-decode each segment if needed in your programming language
   - Join segments back with a '/'
@@ -411,7 +411,7 @@ To parse a ``purl`` string in its components:
 
   - Discard any empty segment from that split
   - Percent-decode each segment
-  - UTF-8-decode each segment if needed in your programming
+  - UTF-8-decode the each segment if needed in your programming
     language
   - Apply type-specific normalization to each segment if needed
   - Join segments back with a '/'
@@ -433,7 +433,7 @@ identification to ensure that a ``purl`` stays compact and readable in most case
 
 Additional, separate external attributes stored outside of a ``purl`` are the
 preferred mechanism to convey extra long and optional information such as a
-download URL, VCS URL or checksums in an API, database or web form.
+download URL, vcs URL or checksums in an API, database or web form.
 
 
 With this warning, the known ``key`` and ``value`` defined here are valid for use in

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -172,7 +172,7 @@ cpan
 ----
 ``cpan`` for CPAN Perl packages:
 
-- The default respository is ``https://www.cpan.org/``.
+- The default repository is ``https://www.cpan.org/``.
 - The ``namespace``:
   - To refer to a CPAN distribution name, the ``namespace`` MUST be present. In this case, the namespace is the CPAN id of the author/publisher. It MUST be written uppercase, followed by the distribution name in the ``name`` component. A distribution name may NEVER contain the string ``::``.
   - To refer to a CPAN module, the ``namespace`` MUST be absent. The module name MAY contain zero or more ``::`` strings, and the module name MUST NOT contain a ``-``
@@ -182,7 +182,7 @@ cpan
 - Optional qualifiers may include:
 
   - ``repository_url``: CPAN/MetaCPAN/BackPAN/DarkPAN repository base URL (default is ``https://www.cpan.org``)
-  - ``download_url``: URL of package or distibution
+  - ``download_url``: URL of package or distribution
   - ``vcs_url``: extra URL for a package version control system
   - ``ext``: file extension (default is ``tar.gz``)
 
@@ -252,7 +252,7 @@ docker
 
 gem
 ---
-``gem`` for Rubygems:
+``gem`` for RubyGems:
 
 - The default repository is ``https://rubygems.org``.
 - The ``platform`` qualifiers key is used to specify an alternative platform.
@@ -374,7 +374,7 @@ luarocks
   The full version number is required to uniquely identify a version.
 - Qualifier ``repository_url``: The LuaRocks rocks server to be used;
   useful in case a private server is used (optional).
-  If ommitted, ``https://luarocks.org`` as default server is assumed.
+  If omitted, ``https://luarocks.org`` as default server is assumed.
 
 Examples::
 

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ A `purl` or package URL is an attempt to standardize existing approaches to
 reliably identify and locate software packages.
 
 A `purl` is a URL string used to identify and locate a software package in a
-mostly universal and uniform way across programing languages, package managers,
+mostly universal and uniform way across programming languages, package managers,
 packaging conventions, tools, APIs and databases.
 
 Such a package URL is useful to reliably reference the same software package

--- a/VERSION-RANGE-SPEC.rst
+++ b/VERSION-RANGE-SPEC.rst
@@ -59,9 +59,9 @@ conventions in use:
 - ``semver`` https://semver.org/ is a popular specification to structure version
   strings, but does not provide a way to express version ranges.
 
-- Rubygems strongly suggest using ``semver`` for version but does not enforce it.
+- RubyGems strongly suggest using ``semver`` for version but does not enforce it.
   As a result some gem use semver while several popular package do not use
-  strict semver. Rubygems use their own notation for version ranges which
+  strict semver. RubyGems use their own notation for version ranges which
   looks like the ``node-semver`` notation with some subtle differences.
   See https://guides.rubygems.org/patterns/#semantic-versioning
 
@@ -142,7 +142,7 @@ related topic:
 - For instance, ``semver`` is a prominent specification in this domain but this
   is just one of the many ways to structure a version string.
 
-- Debian, RPM, PyPI, Rubygems, and Composer have their own subtly different
+- Debian, RPM, PyPI, RubyGems, and Composer have their own subtly different
   approach on how to determine how two versions are compared as equal, greater
   or lesser.
 
@@ -260,7 +260,7 @@ Note how the constraints are sorted:
   - ``vers:tomee/>=7.1.0|<=7.1.2``
   - ``vers:tomee/>=8.0.0-M1|<=8.0.1``
 
-Conversing Rubygems custom syntax for dependency on gem. Note how the
+Conversing RubyGems custom syntax for dependency on gem. Note how the
 pessimistic version constraint is expanded:
 
 - ``'library', '~> 2.2.0', '!= 2.2.1'``
@@ -603,9 +603,9 @@ These are a few known versioning schemes for some common Package URL
   Debian uses these comparators: <<, <=, =, >= and >>.
 
 - **rpm**: RPM distros https://rpm-software-management.github.io/rpm/manual/dependencies.html
-  The a simplified rmpvercmp version comparison routine is used by archlinux Pacman.
+  The a simplified rmpvercmp version comparison routine is used by Arch Linux Pacman.
 
-- **gem**: Rubygems https://guides.rubygems.org/patterns/#semantic-versioning
+- **gem**: RubyGems https://guides.rubygems.org/patterns/#semantic-versioning
   which is similar to ``node-semver`` for its syntax, but does not use semver
   versions.
 
@@ -692,7 +692,7 @@ Why not reuse existing version range notations?
 
 Most existing version range notations are tied to a specific version string
 syntax and are therefore not readily applicable to other contexts. For example,
-the use of elements such as tilde and caret ranges in Rubygems, npm or Dart
+the use of elements such as tilde and caret ranges in RubyGems, npm or Dart
 notations implies that a certain structure exists in the version string (semver
 or semver- like). The inclusion of these additional comparators is a result of
 the history and evolution in a given package ecosystem to address specific needs.
@@ -900,14 +900,14 @@ aspects specific to the versions used only in the Python ecosystem.
   difficult to express without an "OR" logic.
 
 
-Why not use Rubygems requirements notation?
+Why not use RubyGems requirements notation?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 See:
 
 - https://guides.rubygems.org/patterns/#declaring-dependencies
 
-The Rubygems specification suggests but does not enforce using semver. It uses
+The RubyGems specification suggests but does not enforce using semver. It uses
 operators similar to the ``node-semver`` spec with the different of the "~>"
 aka. pessimistic operator vs. a plain "~" tilde used in node-semver.  This
 operator implies some semver-like versioning, yet gem version are not strictly


### PR DESCRIPTION
Typos:
- respository -> repository
- distibution -> distribution
- ommitted -> omitted
- programing -> programming

Grammar/Style:
- cannot contains -> cannot contain
- decode the each segment -> decode each segment (this will made line 414 written the same as line 364)
- Uppercase first characters of few bullet points to make it consistent with other bullets

Proper nouns (in non-code context)
- vcs -> VCS 
- archlinux -> Arch Linux
- Rubygems -> RubyGems (according to https://rubygems.org/)
