### PR TITLE
Add new spec for `go` package URLs

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -297,6 +297,27 @@ github
       pkg:github/package-url/purl-spec@244fd47e07d1004
       pkg:github/package-url/purl-spec@244fd47e07d1004#everybody/loves/dogs
 
+go
+------
+``go`` for Go modules:
+
+- The ``namespace`` is empty.
+- The ``name`` is the unmodified full case-sensitive [Go module path](https://go.dev/ref/mod#module-path).
+  For artifacts in the Go standard library or the Go command, the ``name`` is `stdlib`.
+- The ``subpath`` is the unmodified Go package path within a module.
+- The ``version`` may be a valid [Go version](https://go.dev/doc/toolchain#version) for `stdlib`,
+  [Go module version](https://go.dev/doc/modules/version-numbers), [`(devel)`](https://go.dev/ref/mod#go-version-m),
+  or omitted when empty.
+- The ``qualifiers`` are URL encoded key-value pairs as defined by
+  Go's [`debug.BuildSetting`](https://pkg.go.dev/runtime/debug#BuildSetting).
+  This list can be extended in the future.
+- Examples::
+
+      pkg:go/google.golang.org%2Fgenproto#googleapis/api/annotations
+      pkg:go/github.com%2Fjmorion%2Fsqlx@v1.1.2#api
+      pkg:go/golang.org%2Fx%2Fvuln?goversion=1.23.2&vcs=git&vcs.modified=true#cmd/govulncheck
+      pkg:go/golang.org%2Fx%2Fvuln@v1.1.3?goos=linux#cmd/govulncheck
+
 golang
 ------
 ``golang`` for Go packages:


### PR DESCRIPTION
Hi folks. This proposal is the same as #338, but I don't know how to commandeer that pull request. 


> The current PURL specification for Go was created before Go 1.11 modules and thus has namespace inconsistencies and lacks semantic versioning.
>
>Although in many cases a module path corresponds directly to the URL of the hosting repository, that is not always true. The URL formed from the module path may be an endpoint that serves a redirect to the true host. This indirection protects projects that for whatever reason must change their hosting provider: their module names will continue to work. Consequently, it is undesirable to encode any aspect of the underlying hosting system as part of the PURL.
>
>In essence, all Go modules form a single namespace. Since it is used by the majority of Go programmers, we propose to represent this namespace by the empty string. Though not included in this commit, other namespaces could be possible and would represent package managers and/or build tools that are alternatives to the go command.
>
>The go type proposed here fixes the current issues by removing the namespace, using valid Go module versions (including pseudoversions), and adds some extra functionality to encode optional information about specific builds (GOOS, GOARCH, etc).
>
>If accepted, all tools maintained by the Go project (such as govulncheck and [pkg.go.dev](http://pkg.go.dev/)) that surface PURLs will use this new type to provide canonical PURLs for Go modules and packages


To bring everyone up to speed, I wanted to summarize discussion on #338: 1) what this proposal brings to the table and 2) major concerns as well as how those concerns might be addressed. We can add and cross things in this post to keep track of the progress.

### Proposal main points

Adding a new PURL type `go` where we:

- **Use only namespace for module information.** It is hard and sometimes impossible to figure out what the name should be. As of writing this, there are >57k Go modules that do not start with `github.com`. In general, there seem to be plenty of modules for which it is unclear what the name is. Special-casing on these will not scale, especially since we can also expect new modules in the future. Some of these examples are particularly tricky, one such being `gotest.tools`.

- **We will use `stdlib` as the module for artifacts in the go command or standard library.** Consistency with other Go tooling breaks the tie with `std` option.

- **Use only versions produced by the Go tooling (or no versions at all).** This includes pseudo versions. Hashes should not be allowed. The go command will [soon](https://github.com/golang/go/issues/50603) stamp effectively all binaries with a pseudo-version, even in the presence of pending changes and no tags. Though, we will also support `(devel)` for legacy reasons.

### Concerns

- **_This can be accomplished by updating documentation of `golang` type._** It is not clear how this can actually be achieved. At the very least, it seems that addressing [#308](https://github.com/package-url/purl-spec/issues/308) this way would be a breaking change.

- **_This introduces a breaking change. There are differences between `golang` and `go` PURL types such that replacing former with the latter can introduce breaking changes_.** Let us put aside that this is technically not a breaking change. The `golang` type predates Go modules. Just as Go as the language and ecosystem evolved, so should its PURL spec. There is sufficient evidence ([#63](https://github.com/package-url/purl-spec/issues/63), [#196](https://github.com/package-url/purl-spec/pull/196), [#294](https://github.com/package-url/purl-spec/issues/294), [#308](https://github.com/package-url/purl-spec/issues/308)) that `golang` PURL type creates problems and there should be a type that addresses its shortcomings. If name is the problem, the newly proposed type might also be called `gomod`?

- **_Namespace are percent-encoded and that will make things hard to read for users_.** We feel this is a small price to pay. Further, tools rendering `go` PURLs can pretty-print the namespace to users.


@jkowalleck @matt-phylum @pombredanne 