### PR TITLE
Clarify encoding of colon between scheme and type

### DIFF
--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -247,8 +247,9 @@ Use these rules for percent-encoding and decoding ``purl`` components:
 - the '#', '?', '@' and ':' characters must NOT be encoded when used as
   separators. They may need to be encoded elsewhere
 
-- the ':' ``scheme`` and ``type`` separator does not need to and must NOT be encoded.
-  It is unambiguous unencoded everywhere
+- The colon ':' separator between ``scheme`` and ``type`` MUST NOT be encoded.
+  For example, in the PURL snippet ``pkg:npm`` the colon ':' MUST NOT be encoded,
+  and the PURL snippet ``pkg%3Anpm`` is invalid.
 
 - the '/' used as ``type``/``namespace``/``name`` and ``subpath`` segments separator
   does not need to and must NOT be percent-encoded. It is unambiguous unencoded

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -123,8 +123,8 @@ The rules for each component are:
 - **scheme**:
 
   - The ``scheme`` is a constant with the value "pkg".
-  - The scheme and type MUST be separated by a colon ':'.
-  - ``purl`` parsers MUST accept URLs in which the scheme and colon ':' are
+  - The ``scheme`` and ``type`` MUST be separated by a colon ':'.
+  - ``purl`` parsers MUST accept URLs in which the ``scheme`` and colon ':' are
     followed by one or more slash '/' characters, such as 'pkg://', and MUST
     ignore -- i.e., normalize by removing -- all such '/' characters.
 

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -220,7 +220,7 @@ Character encoding
 
 For clarity and simplicity a ``purl`` is always an ASCII string. To ensure that
 there is no ambiguity when parsing a ``purl``, separator characters and non-ASCII
-characters MUST be UTF-encoded and then percent-encoded as defined at::
+characters must be UTF-encoded and then percent-encoded as defined at::
 
     https://en.wikipedia.org/wiki/Percent-encoding
 

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -123,10 +123,10 @@ The rules for each component are:
 - **scheme**:
 
   - The ``scheme`` is a constant with the value "pkg".
-  - The ``scheme`` and ``type`` MUST be separated by a colon ':'.
-  - ``purl`` parsers MUST accept URLs in which the ``scheme`` and colon ':' are
+  - The ``scheme`` MUST be followed by an unencoded colon ':'.
+  - ``purl`` parsers MUST accept URLs where the ``scheme`` and colon ':' are
     followed by one or more slash '/' characters, such as 'pkg://', and MUST
-    ignore -- i.e., normalize by removing -- all such '/' characters.
+    ignore and remove all such '/' characters.
 
 
 - **type**:
@@ -218,10 +218,9 @@ The rules for each component are:
 Character encoding
 ~~~~~~~~~~~~~~~~~~
 
-For clarity and simplicity, a ``purl`` is always an ASCII string. To ensure that
-there is no ambiguity when parsing a ``purl``, unless otherwise provided in
-this specification, separator characters and non-ASCII characters MUST be
-UTF-encoded and then percent-encoded as defined at::
+For clarity and simplicity a ``purl`` is always an ASCII string. To ensure that
+there is no ambiguity when parsing a ``purl``, separator characters and non-ASCII
+characters MUST be UTF-encoded and then percent-encoded as defined at::
 
     https://en.wikipedia.org/wiki/Percent-encoding
 
@@ -229,13 +228,11 @@ Use these rules for percent-encoding and decoding ``purl`` components:
 
 - the ``type`` must NOT be encoded and must NOT contain separators
 
-- the '#', '?', '@' and ':' characters MUST remain unencoded and displayed
-  as-is when used as separators. They may need to be encoded elsewhere.
+- the '#', '?', '@' and ':' characters must NOT be encoded when used as
+  separators. They may need to be encoded elsewhere
 
-- the colon ':' separator between ``scheme`` and ``type`` MUST remain unencoded.
-  For example, in the PURL snippet ``pkg:npm`` the colon ':' MUST remain
-  unencoded and displayed as-is, i.e., ``pkg:npm``, and the PURL snippet
-  ``pkg%3Anpm`` is invalid.
+- the ':' ``scheme`` and ``type`` separator does not need to and must NOT be encoded.
+  It is unambiguous unencoded everywhere
 
 - the '/' used as ``type``/``namespace``/``name`` and ``subpath`` segments separator
   does not need to and must NOT be percent-encoded. It is unambiguous unencoded
@@ -246,7 +243,7 @@ Use these rules for percent-encoding and decoding ``purl`` components:
 - the '=' ``qualifiers`` key/value separator must NOT be encoded
 - the '#' ``subpath`` separator must be encoded as ``%23`` elsewhere
 
-- All non-ASCII characters MUST be encoded as UTF-8 and then percent-encoded.
+- All non-ASCII characters must be encoded as UTF-8 and then percent-encoded
 
 It is OK to percent-encode ``purl`` components otherwise except for the ``type``.
 Parsers and builders must always percent-decode and percent-encode ``purl``

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -55,7 +55,7 @@ sometimes look like a ``host`` but its interpretation is specific to a ``type``.
 
 
 Some ``purl`` examples
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 
@@ -72,7 +72,7 @@ Some ``purl`` examples
 
 
 A ``purl`` is a URL
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 - A ``purl`` is a valid URL and URI that conforms to the URL definitions or
   specifications at:
@@ -110,7 +110,7 @@ A ``purl`` is a URL
 
 
 Rules for each ``purl`` component
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A ``purl`` string is an ASCII URL string composed of seven components.
 
@@ -122,27 +122,11 @@ The rules for each component are:
 
 - **scheme**:
 
-  - The ``scheme`` is a constant with the value "pkg"
-  - Since a ``purl`` never contains a URL Authority, its ``scheme`` must not be
-    suffixed with double slash as in 'pkg://' and should use instead
-    'pkg:'. Otherwise this would be an invalid URI per rfc3986 at
-    https://tools.ietf.org/html/rfc3986#section-3.3::
-
-        If a URI does not contain an authority component, then the path
-        cannot begin with two slash characters ("//").
-
-    It is therefore incorrect to use such '://' scheme suffix as the URL would
-    no longer be valid otherwise. In its canonical form, a ``purl`` must
-    NOT use such '://' ``scheme`` suffix but only ':' as a ``scheme`` suffix.
-  - ``purl`` parsers must accept URLs such as 'pkg://' and must ignore the '//'.
-  - ``purl`` builders must not create invalid URLs with such double slash '//'.
-  - The ``scheme`` is followed by a ':' separator
-  - For example these two purls are strictly equivalent and the first is in
-    canonical form. The second ``purl`` with a '//' is an acceptable ``purl`` but is
-    an invalid URI/URL per rfc3986::
-
-            pkg:gem/ruby-advisory-db-check@0.12.4
-            pkg://gem/ruby-advisory-db-check@0.12.4
+  - The ``scheme`` is a constant with the value "pkg".
+  - The scheme and type MUST be separated by a colon ':'.
+  - ``purl`` parsers MUST accept URLs in which the scheme and colon ':' are
+    followed by one or more slash '/' characters, such as 'pkg://', and MUST
+    ignore -- i.e., normalize by removing -- all such '/' characters.
 
 
 - **type**:
@@ -234,9 +218,10 @@ The rules for each component are:
 Character encoding
 ~~~~~~~~~~~~~~~~~~
 
-For clarity and simplicity a ``purl`` is always an ASCII string. To ensure that
-there is no ambiguity when parsing a ``purl``, separator characters and non-ASCII
-characters must be UTF-encoded and then percent-encoded as defined at::
+For clarity and simplicity, a ``purl`` is always an ASCII string. To ensure that
+there is no ambiguity when parsing a ``purl``, unless otherwise provided in
+this specification, separator characters and non-ASCII characters MUST be
+UTF-encoded and then percent-encoded as defined at::
 
     https://en.wikipedia.org/wiki/Percent-encoding
 
@@ -244,12 +229,13 @@ Use these rules for percent-encoding and decoding ``purl`` components:
 
 - the ``type`` must NOT be encoded and must NOT contain separators
 
-- the '#', '?', '@' and ':' characters must NOT be encoded when used as
-  separators. They may need to be encoded elsewhere
+- the '#', '?', '@' and ':' characters MUST remain unencoded and displayed
+  as-is when used as separators. They may need to be encoded elsewhere.
 
-- The colon ':' separator between ``scheme`` and ``type`` MUST NOT be encoded.
-  For example, in the PURL snippet ``pkg:npm`` the colon ':' MUST NOT be encoded,
-  and the PURL snippet ``pkg%3Anpm`` is invalid.
+- the colon ':' separator between ``scheme`` and ``type`` MUST remain unencoded.
+  For example, in the PURL snippet ``pkg:npm`` the colon ':' MUST remain
+  unencoded and displayed as-is, i.e., ``pkg:npm``, and the PURL snippet
+  ``pkg%3Anpm`` is invalid.
 
 - the '/' used as ``type``/``namespace``/``name`` and ``subpath`` segments separator
   does not need to and must NOT be percent-encoded. It is unambiguous unencoded
@@ -260,7 +246,7 @@ Use these rules for percent-encoding and decoding ``purl`` components:
 - the '=' ``qualifiers`` key/value separator must NOT be encoded
 - the '#' ``subpath`` separator must be encoded as ``%23`` elsewhere
 
-- All non-ASCII characters must be encoded as UTF-8 and then percent-encoded
+- All non-ASCII characters MUST be encoded as UTF-8 and then percent-encoded.
 
 It is OK to percent-encode ``purl`` components otherwise except for the ``type``.
 Parsers and builders must always percent-decode and percent-encode ``purl``
@@ -269,7 +255,7 @@ build" sections.
 
 
 How to build ``purl`` string from its components
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Building a ``purl`` ASCII string works from left to right, from ``type`` to
 ``subpath``.
@@ -344,7 +330,7 @@ To build a ``purl`` string from its components:
 
 
 How to parse a ``purl`` string in its components
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Parsing a ``purl`` ASCII string into its components works from right to left,
 from ``subpath`` to ``type``.
@@ -387,7 +373,8 @@ To parse a ``purl`` string in its components:
   - The left side lowercased is the ``scheme``
   - The right side is the ``remainder``
 
-- Strip the ``remainder`` from leading and trailing '/'
+- Strip all leading and trailing '/' characters (e.g., '/', '//', '///' and
+  so on) from the ``remainder``
 
   - Split this once from left on '/'
   - The left side lowercased is the ``type``
@@ -425,7 +412,7 @@ There are several known ``purl`` package type definitions tracked in the
 separate `<PURL-TYPES.rst>`_ document.
 
 Known ``qualifiers`` key/value pairs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Note: Do not abuse ``qualifiers``: it can be tempting to use many qualifier
 keys but their usage should be limited to the bare minimum for proper package

--- a/faq.rst
+++ b/faq.rst
@@ -1,0 +1,68 @@
+Frequently Asked Questions
+==========================
+
+Components
+~~~~~~~~~~
+
+Scheme
+------
+
+Q: Can the scheme component be followed by a colon and two slashes, like a URI?
+
+A: No.  Since a ``purl`` never contains a URL Authority, its ``scheme`` MUST NOT be suffixed with double slash as in 'pkg://' and SHOULD use instead 'pkg:'. Otherwise this would be an invalid URI per rfc3986 at https://tools.ietf.org/html/rfc3986#section-3.3::
+
+    If a URI does not contain an authority component, then the path
+    cannot begin with two slash characters ("//").
+
+It is therefore incorrect to use such '://' scheme suffix as the URL would no longer be valid otherwise. This rule applies to all slash '/' characters between the scheme's colon separator and the type component, e.g., ':/', '://', ':///' et al.  In its canonical form, a ``purl`` MUST NOT use any such ':/' ``scheme`` suffix and may only use ':' as a ``scheme`` suffix.
+
+- ``purl`` parsers MUST accept URLs such as 'pkg://'and MUST ignore -- i.e., normalize by deleting -- all such '/' characters.
+- ``purl`` builders MUST NOT create invalid URLs with such double slash '//'.
+- For example these two purls are strictly equivalent and the first is in canonical form. The second ``purl`` with a '//' is an acceptable ``purl`` but is an invalid URI/URL per rfc3986::
+
+    pkg:gem/ruby-advisory-db-check@0.12.4
+    pkg://gem/ruby-advisory-db-check@0.12.4
+
+----
+
+Q: Is the colon between scheme and type encoded? Can it be encoded? If yes, how?
+
+A: The "Rules for each ``purl`` component" section provides that "[t]he scheme and type MUST be separated by a colon ':'".  In addition, the "Character encoding" section provides that "the '#', '?', '@' and ':' characters MUST remain unencoded and displayed as-is when used as separators."
+
+The colon ':' between scheme and type is being used as a separator, and consequently SHOULD be used as-is, never encoded and never requiring any decoding. Moreover, it SHOULD be a parsing error if the colon ':' does not come directly after 'pkg'.  Tools are welcome to recover from this error to help with damaged PURLs, but that's not a requirement.
+
+
+Type
+----
+
+- to come
+
+
+Namespace
+---------
+
+- to come
+
+
+Name
+----
+
+- to come
+
+
+Version
+-------
+
+- to come
+
+
+Qualifiers
+----------
+
+- to come
+
+
+Subpath
+-------
+
+- to come

--- a/faq.rst
+++ b/faq.rst
@@ -7,71 +7,71 @@ Components
 Scheme
 ------
 
-    **QUESTION:** Can the ``scheme`` component be followed by a colon and two slashes, like a URI?
+**QUESTION:** Can the ``scheme`` component be followed by a colon and two slashes, like a URI?
 
-    No.  Since a Package-URL, or PURL, never contains a URL Authority, its ``scheme`` should not be suffixed with double slash as in 'pkg://' and should use 'pkg:' instead. Otherwise this would be an invalid URI per RFC 3986 at https://tools.ietf.org/html/rfc3986#section-3.3::
+No.  Since a Package-URL, or PURL, never contains a URL Authority, its ``scheme`` should not be suffixed with double slash as in 'pkg://' and should use 'pkg:' instead. Otherwise this would be an invalid URI per RFC 3986 at https://tools.ietf.org/html/rfc3986#section-3.3::
 
-        If a URI does not contain an authority component, then the path
-        cannot begin with two slash characters ("//").
+    If a URI does not contain an authority component, then the path
+    cannot begin with two slash characters ("//").
 
-    This rule applies to all slash '/' characters between the ``scheme``'s colon separator and the ``type`` component, e.g., ':/', '://', ':///' et al.
+This rule applies to all slash '/' characters between the ``scheme``'s colon separator and the ``type`` component, e.g., ':/', '://', ':///' et al.
 
-    In its canonical form, a PURL must not use any such ':/' ``scheme`` suffix and may only use ':' as a ``scheme`` suffix.  This means that:
+In its canonical form, a PURL must not use any such ':/' ``scheme`` suffix and may only use ':' as a ``scheme`` suffix.  This means that:
 
-    - PURL parsers must accept URLs such as 'pkg://'and must ignore -- i.e., normalize by deleting -- all such '/' characters.
-    - PURL builders should not create invalid URLs with one or more slash '/' characters between 'pkg:' and the `type` component.
+- PURL parsers must accept URLs such as 'pkg://'and must ignore -- i.e., normalize by deleting -- all such '/' characters.
+- PURL builders should not create invalid URLs with one or more slash '/' characters between 'pkg:' and the `type` component.
 
-    For example, although these two PURLs are strictly equivalent, the first is in canonical form, while the second -- with a '//' between 'pkg:' and the ``type`` 'gem' -- is an acceptable PURL but is an invalid URI/URL per RFC 3986::
+For example, although these two PURLs are strictly equivalent, the first is in canonical form, while the second -- with a '//' between 'pkg:' and the ``type`` 'gem' -- is an acceptable PURL but is an invalid URI/URL per RFC 3986::
 
-        pkg:gem/ruby-advisory-db-check@0.12.4
+    pkg:gem/ruby-advisory-db-check@0.12.4
 
-        pkg://gem/ruby-advisory-db-check@0.12.4
+    pkg://gem/ruby-advisory-db-check@0.12.4
 
 ----
 
-    **QUESTION:** Is the colon between ``scheme`` and ``type`` encoded? Can it be encoded? If yes, how?
+**QUESTION:** Is the colon between ``scheme`` and ``type`` encoded? Can it be encoded? If yes, how?
 
-    There are two sections of the core specification that address this question:
+There are two sections of the core specification that address this question:
 
-    - The "Rules for each ``purl`` component" section provides that "[t]he ``scheme`` and ``type`` MUST be separated by a colon ':'".
-    - The "Character encoding" section provides that
+- The "Rules for each ``purl`` component" section provides that "[t]he ``scheme`` and ``type`` MUST be separated by a colon ':'".
+- The "Character encoding" section provides that
 
-        the '#', '?', '@' and ':' characters MUST remain unencoded and displayed as-is when used as separators.  . . .  [T]he colon ':' separator between ``scheme`` and ``type`` MUST remain unencoded.  For example, in the PURL snippet ``pkg:npm`` the colon ':' MUST remain unencoded and displayed as-is, i.e., ``pkg:npm``, and the PURL snippet ``pkg%3Anpm`` is invalid.
+    the '#', '?', '@' and ':' characters MUST remain unencoded and displayed as-is when used as separators.  . . .  [T]he colon ':' separator between ``scheme`` and ``type`` MUST remain unencoded.  For example, in the PURL snippet ``pkg:npm`` the colon ':' MUST remain unencoded and displayed as-is, i.e., ``pkg:npm``, and the PURL snippet ``pkg%3Anpm`` is invalid.
 
-    In this case, the colon ':' between ``scheme`` and ``type`` is being used as a separator, and consequently should be used as-is, never encoded and never requiring any decoding. Moreover, it should be a parsing error if the colon ':' does not come directly after 'pkg'.  Tools are welcome to recover from this error to help with damaged PURLs, but that's not a requirement.
+In this case, the colon ':' between ``scheme`` and ``type`` is being used as a separator, and consequently should be used as-is, never encoded and never requiring any decoding. Moreover, it should be a parsing error if the colon ':' does not come directly after 'pkg'.  Tools are welcome to recover from this error to help with damaged PURLs, but that's not a requirement.
 
 
 Type
 ----
 
-    [to come]
+[to come]
 
 
 Namespace
 ---------
 
-    [to come]
+[to come]
 
 
 Name
 ----
 
-    [to come]
+[to come]
 
 
 Version
 -------
 
-    [to come]
+[to come]
 
 
 Qualifiers
 ----------
 
-    [to come]
+[to come]
 
 
 Subpath
 -------
 
-    [to come]
+[to come]

--- a/faq.rst
+++ b/faq.rst
@@ -30,8 +30,8 @@ This rule applies to all slash '/' characters between the ``scheme``'s colon sep
 
 In its canonical form, a PURL must not use any such ':/' ``scheme`` suffix and may only use ':' as a ``scheme`` suffix.  This means that:
 
-- PURL parsers must accept URLs such as 'pkg://'and must ignore -- i.e., normalize by deleting -- all such '/' characters.
-- PURL builders should not create invalid URLs with one or more slash '/' characters between 'pkg:' and the `type` component.
+- PURL parsers must accept URLs such as 'pkg://' and must ignore and remove all such '/' characters.
+- PURL builders should not create invalid URLs with one or more slash '/' characters between 'pkg:' and the ``type`` component.
 
 For example, although these two PURLs are strictly equivalent, the first is in canonical form, while the second -- with a '//' between 'pkg:' and the ``type`` 'gem' -- is an acceptable PURL but is an invalid URI/URL per RFC 3986::
 
@@ -41,53 +41,6 @@ For example, although these two PURLs are strictly equivalent, the first is in c
 
 **QUESTION**: Is the colon between ``scheme`` and ``type`` encoded? Can it be encoded? If yes, how?
 
-There are two sections of the core specification that address this question:
-
-- The "Rules for each ``purl`` component" section provides that "[t]he ``scheme`` and ``type`` MUST be separated by a colon ':'".
-- The "Character encoding" section provides that
-
-    the '#', '?', '@' and ':' characters MUST remain unencoded and displayed as-is when used as separators.  . . .  [T]he colon ':' separator between ``scheme`` and ``type`` MUST remain unencoded.  For example, in the PURL snippet ``pkg:npm`` the colon ':' MUST remain unencoded and displayed as-is, i.e., ``pkg:npm``, and the PURL snippet ``pkg%3Anpm`` is invalid.
+The "Rules for each ``purl`` component" section provides that "[t]he ``scheme`` MUST be followed by an unencoded colon ':'.
 
 In this case, the colon ':' between ``scheme`` and ``type`` is being used as a separator, and consequently should be used as-is, never encoded and never requiring any decoding. Moreover, it should be a parsing error if the colon ':' does not come directly after 'pkg'.  Tools are welcome to recover from this error to help with damaged PURLs, but that's not a requirement.
-
-----
-
-Type
-----
-
-[to come]
-
-----
-
-Namespace
----------
-
-[to come]
-
-----
-
-Name
-----
-
-[to come]
-
-----
-
-Version
--------
-
-[to come]
-
-----
-
-Qualifiers
-----------
-
-[to come]
-
-----
-
-Subpath
--------
-
-[to come]

--- a/faq.rst
+++ b/faq.rst
@@ -1,11 +1,8 @@
 Frequently Asked Questions
 ==========================
 
-Components
-~~~~~~~~~~
-
 Scheme
-------
+~~~~~~
 
 **QUESTION**: Can the ``scheme`` component be followed by a colon and two slashes, like a URI?
 

--- a/faq.rst
+++ b/faq.rst
@@ -1,13 +1,25 @@
 Frequently Asked Questions
 ==========================
 
+The following FAQs are organized into
+
+- a "Components" section that includes each of the seven PURL components
+  (``scheme``, ``type``, ``namespace``, ``name``, ``version``, ``qualifiers``
+  and ``subpath``), and
+
+- a "General" section containing a mix of questions and answers that don't fit
+  neatly into a component-focused category.
+
+If you have a question about the PURL specification and don't find an answer
+below, you can open an issue `here <https://github.com/package-url/purl-spec/issues/new?template=Blank+issue>`_.
+
 Components
 ~~~~~~~~~~
 
 Scheme
 ------
 
-**QUESTION:** Can the ``scheme`` component be followed by a colon and two slashes, like a URI?
+**QUESTION**: Can the ``scheme`` component be followed by a colon and two slashes, like a URI?
 
 No.  Since a Package-URL, or PURL, never contains a URL Authority, its ``scheme`` should not be suffixed with double slash as in 'pkg://' and should use 'pkg:' instead. Otherwise this would be an invalid URI per RFC 3986 at https://tools.ietf.org/html/rfc3986#section-3.3::
 
@@ -27,9 +39,7 @@ For example, although these two PURLs are strictly equivalent, the first is in c
 
     pkg://gem/ruby-advisory-db-check@0.12.4
 
-----
-
-**QUESTION:** Is the colon between ``scheme`` and ``type`` encoded? Can it be encoded? If yes, how?
+**QUESTION**: Is the colon between ``scheme`` and ``type`` encoded? Can it be encoded? If yes, how?
 
 There are two sections of the core specification that address this question:
 
@@ -40,36 +50,42 @@ There are two sections of the core specification that address this question:
 
 In this case, the colon ':' between ``scheme`` and ``type`` is being used as a separator, and consequently should be used as-is, never encoded and never requiring any decoding. Moreover, it should be a parsing error if the colon ':' does not come directly after 'pkg'.  Tools are welcome to recover from this error to help with damaged PURLs, but that's not a requirement.
 
+----
 
 Type
 ----
 
 [to come]
 
+----
 
 Namespace
 ---------
 
 [to come]
 
+----
 
 Name
 ----
 
 [to come]
 
+----
 
 Version
 -------
 
 [to come]
 
+----
 
 Qualifiers
 ----------
 
 [to come]
 
+----
 
 Subpath
 -------

--- a/faq.rst
+++ b/faq.rst
@@ -10,9 +10,6 @@ The following FAQs are organized into
 - a "General" section containing a mix of questions and answers that don't fit
   neatly into a component-focused category.
 
-If you have a question about the PURL specification and don't find an answer
-below, you can open an issue `here <https://github.com/package-url/purl-spec/issues/new?template=Blank+issue>`_.
-
 Components
 ~~~~~~~~~~
 
@@ -21,19 +18,19 @@ Scheme
 
 **QUESTION**: Can the ``scheme`` component be followed by a colon and two slashes, like a URI?
 
-No.  Since a Package-URL, or PURL, never contains a URL Authority, its ``scheme`` should not be suffixed with double slash as in 'pkg://' and should use 'pkg:' instead. Otherwise this would be an invalid URI per RFC 3986 at https://tools.ietf.org/html/rfc3986#section-3.3::
+No.  Since a ``purl`` never contains a URL Authority, its ``scheme`` should not be suffixed with double slash as in 'pkg://' and should use 'pkg:' instead. Otherwise this would be an invalid URI per RFC 3986 at https://tools.ietf.org/html/rfc3986#section-3.3::
 
     If a URI does not contain an authority component, then the path
     cannot begin with two slash characters ("//").
 
 This rule applies to all slash '/' characters between the ``scheme``'s colon separator and the ``type`` component, e.g., ':/', '://', ':///' et al.
 
-In its canonical form, a PURL must not use any such ':/' ``scheme`` suffix and may only use ':' as a ``scheme`` suffix.  This means that:
+In its canonical form, a ``purl`` must not use any such ':/' ``scheme`` suffix and may only use ':' as a ``scheme`` suffix.  This means that:
 
-- PURL parsers must accept URLs such as 'pkg://' and must ignore and remove all such '/' characters.
-- PURL builders should not create invalid URLs with one or more slash '/' characters between 'pkg:' and the ``type`` component.
+- ``purl`` parsers must accept URLs such as 'pkg://' and must ignore and remove all such '/' characters.
+- ``purl`` builders should not create invalid URLs with one or more slash '/' characters between 'pkg:' and the ``type`` component.
 
-For example, although these two PURLs are strictly equivalent, the first is in canonical form, while the second -- with a '//' between 'pkg:' and the ``type`` 'gem' -- is an acceptable PURL but is an invalid URI/URL per RFC 3986::
+For example, although these two purls are strictly equivalent, the first is in canonical form, while the second -- with a '//' between 'pkg:' and the ``type`` 'gem' -- is an acceptable purl but is an invalid URI/URL per RFC 3986::
 
     pkg:gem/ruby-advisory-db-check@0.12.4
 
@@ -43,4 +40,4 @@ For example, although these two PURLs are strictly equivalent, the first is in c
 
 The "Rules for each ``purl`` component" section provides that "[t]he ``scheme`` MUST be followed by an unencoded colon ':'.
 
-In this case, the colon ':' between ``scheme`` and ``type`` is being used as a separator, and consequently should be used as-is, never encoded and never requiring any decoding. Moreover, it should be a parsing error if the colon ':' does not come directly after 'pkg'.  Tools are welcome to recover from this error to help with damaged PURLs, but that's not a requirement.
+In this case, the colon ':' between ``scheme`` and ``type`` is being used as a separator, and consequently should be used as-is, never encoded and never requiring any decoding. Moreover, it should be a parsing error if the colon ':' does not come directly after 'pkg'.  Tools are welcome to recover from this error to help with malformed purls, but that's not a requirement.

--- a/faq.rst
+++ b/faq.rst
@@ -1,15 +1,6 @@
 Frequently Asked Questions
 ==========================
 
-The following FAQs are organized into
-
-- a "Components" section that includes each of the seven PURL components
-  (``scheme``, ``type``, ``namespace``, ``name``, ``version``, ``qualifiers``
-  and ``subpath``), and
-
-- a "General" section containing a mix of questions and answers that don't fit
-  neatly into a component-focused category.
-
 Components
 ~~~~~~~~~~
 

--- a/faq.rst
+++ b/faq.rst
@@ -7,62 +7,71 @@ Components
 Scheme
 ------
 
-Q: Can the scheme component be followed by a colon and two slashes, like a URI?
+    **QUESTION:** Can the ``scheme`` component be followed by a colon and two slashes, like a URI?
 
-A: No.  Since a ``purl`` never contains a URL Authority, its ``scheme`` MUST NOT be suffixed with double slash as in 'pkg://' and SHOULD use instead 'pkg:'. Otherwise this would be an invalid URI per rfc3986 at https://tools.ietf.org/html/rfc3986#section-3.3::
+    No.  Since a Package-URL, or PURL, never contains a URL Authority, its ``scheme`` should not be suffixed with double slash as in 'pkg://' and should use 'pkg:' instead. Otherwise this would be an invalid URI per RFC 3986 at https://tools.ietf.org/html/rfc3986#section-3.3::
 
-    If a URI does not contain an authority component, then the path
-    cannot begin with two slash characters ("//").
+        If a URI does not contain an authority component, then the path
+        cannot begin with two slash characters ("//").
 
-It is therefore incorrect to use such '://' scheme suffix as the URL would no longer be valid otherwise. This rule applies to all slash '/' characters between the scheme's colon separator and the type component, e.g., ':/', '://', ':///' et al.  In its canonical form, a ``purl`` MUST NOT use any such ':/' ``scheme`` suffix and may only use ':' as a ``scheme`` suffix.
+    This rule applies to all slash '/' characters between the ``scheme``'s colon separator and the ``type`` component, e.g., ':/', '://', ':///' et al.
 
-- ``purl`` parsers MUST accept URLs such as 'pkg://'and MUST ignore -- i.e., normalize by deleting -- all such '/' characters.
-- ``purl`` builders MUST NOT create invalid URLs with such double slash '//'.
-- For example these two purls are strictly equivalent and the first is in canonical form. The second ``purl`` with a '//' is an acceptable ``purl`` but is an invalid URI/URL per rfc3986::
+    In its canonical form, a PURL must not use any such ':/' ``scheme`` suffix and may only use ':' as a ``scheme`` suffix.  This means that:
 
-    pkg:gem/ruby-advisory-db-check@0.12.4
-    pkg://gem/ruby-advisory-db-check@0.12.4
+    - PURL parsers must accept URLs such as 'pkg://'and must ignore -- i.e., normalize by deleting -- all such '/' characters.
+    - PURL builders should not create invalid URLs with one or more slash '/' characters between 'pkg:' and the `type` component.
+
+    For example, although these two PURLs are strictly equivalent, the first is in canonical form, while the second -- with a '//' between 'pkg:' and the ``type`` 'gem' -- is an acceptable PURL but is an invalid URI/URL per RFC 3986::
+
+        pkg:gem/ruby-advisory-db-check@0.12.4
+
+        pkg://gem/ruby-advisory-db-check@0.12.4
 
 ----
 
-Q: Is the colon between scheme and type encoded? Can it be encoded? If yes, how?
+    **QUESTION:** Is the colon between ``scheme`` and ``type`` encoded? Can it be encoded? If yes, how?
 
-A: The "Rules for each ``purl`` component" section provides that "[t]he scheme and type MUST be separated by a colon ':'".  In addition, the "Character encoding" section provides that "the '#', '?', '@' and ':' characters MUST remain unencoded and displayed as-is when used as separators."
+    There are two sections of the core specification that address this question:
 
-The colon ':' between scheme and type is being used as a separator, and consequently SHOULD be used as-is, never encoded and never requiring any decoding. Moreover, it SHOULD be a parsing error if the colon ':' does not come directly after 'pkg'.  Tools are welcome to recover from this error to help with damaged PURLs, but that's not a requirement.
+    - The "Rules for each ``purl`` component" section provides that "[t]he ``scheme`` and ``type`` MUST be separated by a colon ':'".
+    - The "Character encoding" section provides that
+
+        the '#', '?', '@' and ':' characters MUST remain unencoded and displayed as-is when used as separators.  . . .  [T]he colon ':' separator between ``scheme`` and ``type`` MUST remain unencoded.  For example, in the PURL snippet ``pkg:npm`` the colon ':' MUST remain unencoded and displayed as-is, i.e., ``pkg:npm``, and the PURL snippet ``pkg%3Anpm`` is invalid.
+
+    In this case, the colon ':' between ``scheme`` and ``type`` is being used as a separator, and consequently should be used as-is, never encoded and never requiring any decoding. Moreover, it should be a parsing error if the colon ':' does not come directly after 'pkg'.  Tools are welcome to recover from this error to help with damaged PURLs, but that's not a requirement.
 
 
 Type
 ----
 
-- to come
+    [to come]
 
 
 Namespace
 ---------
 
-- to come
+    [to come]
 
 
 Name
 ----
 
-- to come
+    [to come]
 
 
 Version
 -------
 
-- to come
+    [to come]
 
 
 Qualifiers
 ----------
 
-- to come
+    [to come]
 
 
 Subpath
 -------
 
-- to come
+    [to come]

--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -622,5 +622,17 @@
     "qualifiers": null,
     "subpath": null,
     "is_invalid": false
+  },
+  {
+    "description": "invalid encoded colon : between scheme and type",
+    "purl": "pkg%3Amaven/org.apache.commons/io",
+    "canonical_purl": null,
+    "type": "maven",
+    "namespace": "org.apache.commons",
+    "name": "io",
+    "version": null,
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": true
   }
 ]


### PR DESCRIPTION
The colon separator between scheme and type must not be encoded.

This is also using, a new, and not yet adopted wording for MUST according to its definition in RFC2119 as clarified in RFC8174

Suggested-by: @gernot-h
Reference: https://github.com/package-url/purl-spec/issues/39#issuecomment-481422744

JMH: Reference: https://github.com/package-url/purl-spec/issues/376