### PR TITLE
test: character encoding

### DIFF
--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -85,8 +85,8 @@
   },
   {
     "description": "docker uses qualifiers and hash image id as versions",
-    "purl": "pkg:docker/customer/dockerimage@sha256:244fd47e07d1004f0aed9c?repository_url=gcr.io",
-    "canonical_purl": "pkg:docker/customer/dockerimage@sha256:244fd47e07d1004f0aed9c?repository_url=gcr.io",
+    "purl": "pkg:docker/customer/dockerimage@sha256%3A244fd47e07d1004f0aed9c?repository_url=gcr.io",
+    "canonical_purl": "pkg:docker/customer/dockerimage@sha256%3A244fd47e07d1004f0aed9c?repository_url=gcr.io",
     "type": "docker",
     "namespace": "customer",
     "name": "dockerimage",


### PR DESCRIPTION
Correct versions that included a purl with an un-encoded colon in the version (test-suite-data.json:88). Per [purl-spec#character-encoding](https://github.com/package-url/purl-spec#character-encoding)
    
    > the '#', '?', '@' and ':' characters must NOT be encoded when used as separators. They may need to be encoded elsewhere

See #39