### PR TITLE
test: correct test description for leading slashes

### DIFF
--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -252,7 +252,7 @@
     "is_invalid": false
   },
   {
-    "description": "slash /// after type  is not significant",
+    "description": "leading slash /// in front of type  is not significant",
     "purl": "pkg:///maven/org.apache.commons/io",
     "canonical_purl": "pkg:maven/org.apache.commons/io",
     "type": "maven",


### PR DESCRIPTION
Corrected copy-paste issue in the description of the test for /// (test-suite-data.json:255).
