### PR TITLE
test: unencoded subpath cannot contain . or ..

### DIFF
--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -48,6 +48,30 @@
     "is_invalid": false
   },
   {
+    "description": "invalid subpath - unencoded subpath cannot contain ..",
+    "purl": "pkg:GOLANG/google.golang.org/genproto@abcdedf#/googleapis/%2E%2E/api/annotations/",
+    "canonical_purl": "pkg:golang/google.golang.org/genproto@abcdedf#googleapis/api/annotations",
+    "type": "golang",
+    "namespace": "google.golang.org",
+    "name": "genproto",
+    "version": "abcdedf",
+    "qualifiers": null,
+    "subpath": "googleapis/../api/annotations",
+    "is_invalid": true
+  },
+  {
+    "description": "invalid subpath - unencoded subpath cannot contain .",
+    "purl": "pkg:GOLANG/google.golang.org/genproto@abcdedf#/googleapis/%2E/api/annotations/",
+    "canonical_purl": "pkg:golang/google.golang.org/genproto@abcdedf#googleapis/api/annotations",
+    "type": "golang",
+    "namespace": "google.golang.org",
+    "name": "genproto",
+    "version": "abcdedf",
+    "qualifiers": null,
+    "subpath": "googleapis/./api/annotations",
+    "is_invalid": true
+  },
+  {
     "description": "bitbucket namespace and name should be lowercased",
     "purl": "pkg:bitbucket/birKenfeld/pyGments-main@244fd47e07d1014f0aed9c",
     "canonical_purl": "pkg:bitbucket/birkenfeld/pygments-main@244fd47e07d1014f0aed9c",

--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -48,7 +48,7 @@
     "is_invalid": false
   },
   {
-    "description": "invalid subpath - unencoded subpath cannot contain ..",
+    "description": "invalid subpath - unencoded subpath cannot contain '..'",
     "purl": "pkg:GOLANG/google.golang.org/genproto@abcdedf#/googleapis/%2E%2E/api/annotations/",
     "canonical_purl": "pkg:golang/google.golang.org/genproto@abcdedf#googleapis/api/annotations",
     "type": "golang",

--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -57,7 +57,7 @@
     "version": "abcdedf",
     "qualifiers": null,
     "subpath": "googleapis/../api/annotations",
-    "is_invalid": true
+    "is_invalid": false
   },
   {
     "description": "invalid subpath - unencoded subpath cannot contain '.'",
@@ -69,7 +69,7 @@
     "version": "abcdedf",
     "qualifiers": null,
     "subpath": "googleapis/./api/annotations",
-    "is_invalid": true
+    "is_invalid": false
   },
   {
     "description": "bitbucket namespace and name should be lowercased",

--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -60,7 +60,7 @@
     "is_invalid": true
   },
   {
-    "description": "invalid subpath - unencoded subpath cannot contain .",
+    "description": "invalid subpath - unencoded subpath cannot contain '.'",
     "purl": "pkg:GOLANG/google.golang.org/genproto@abcdedf#/googleapis/%2E/api/annotations/",
     "canonical_purl": "pkg:golang/google.golang.org/genproto@abcdedf#googleapis/api/annotations",
     "type": "golang",


### PR DESCRIPTION
Add test cases to check for invalid `.` and `..` segments in the subpath.