### PR TITLE
Clarify namespace for mlflow type

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -416,7 +416,7 @@ mlflow
   - AWS Databricks: ``https://dbc-<alphanumeric>-<alphanumeric>.cloud.databricks.com/api/2.0/mlflow``
   - GCP Databricks: ``https://<numbers>.<number>.gcp.databricks.com/api/2.0/mlflow``
 
-- The ``namespace`` is empty.
+- There is no ``namespace``.
 - The ``name`` is the model name. Case sensitivity depends on the server implementation:
 
   - Azure ML: it is case sensitive and must be kept as-is in the package URL.


### PR DESCRIPTION
mlflow used a reference to an "empty" namespace and was at odds to use this definition with other types.

This clarifies that mlflow does not use a namespace and remove the reference to "empty" namespace.

This is a follow up from @matt-phylum comments in this PR: https://github.com/package-url/purl-spec/pull/373#discussion_r1896747698