### PR TITLE
Add 2025-01-22 PURL community meetings minutes #384

### DIFF
--- a/meetings/2025-01-22.md
+++ b/meetings/2025-01-22.md
@@ -1,0 +1,54 @@
+
+<!-- markdownlint-disable-line MD041 -->
+
+# Agenda for the PURL community meeting on 2025-01-22
+
+- **Host**: Remote
+- **Dates and times**:
+    - 17:00 to 18:00 UTC
+    - 18:00 to 19:00 CEST (Europe/Brussels)
+    - 12:00 to 13:00 EDT (America/New_York)
+    - 09:00 to 10:00 PDT (America/Los Angeles)
+    - 02:00 to 03:00 JST (Tokyo, Japan)
+
+- **Attendee information**:
+  - https://meet.google.com/ydj-qwbs-iiv
+  - [Meeting invite](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=MWliM3RyZXRpdmI4NXFoYXR1MzRkdmg0a3ZfMjAyNTAxMjJUMTcwMDAwWiBjX2Q4YjE1NDIwZGZmMTdiNzk1OWUyOWE1MWFlMzI0MDk1MWNiZTM4ZGIxZGFlNDU5NzJhODVjOWE3MTEyMDQyMDVAZw&tmsrc=c_d8b15420dff17b7959e29a51ae3240951cbe38db1dae45972a85c9a711204205%40group.calendar.google.com&scp=ALL)
+
+## Agenda items
+- Opening of the meeting and welcome
+- Meetings will follow the Ecma TC54 Code of Conduct https://github.com/Ecma-TC54/tg2/blob/main/CODE_OF_CONDUCT.md
+- Overview of current core spec updating
+    - GitHub project board https://github.com/orgs/package-url/projects/1/views/1
+    - component-focused encoding etc.  https://docs.google.com/spreadsheets/d/1biOCUY4eCqQaYmfGDHVrASV9igYEzct6
+    - master issues/PRs https://docs.google.com/spreadsheets/d/1H2QAcADLaMNgcR5BMK7bQxzH5D3X-SdO
+
+## Attendees
+- Philippe Ombredanne, creator of PURL, Lead maintainer of AboutCode, TC54-TG2 convener
+- Adam Herzog, AboutCode
+- John Horan, AboutCode
+- Martin Prpic, Red Hat
+- Doug Clarke, Oracle
+- Jan Kowalleck, Sovereign Tech Agency
+
+## Notes
+- Meeting minutes are being kept and will be published, but the meeting is not being recorded.
+- Our code of conduct (link in agenda above) applies to this meeting.
+- Introductions.
+- Philippe: not an official Ecma call.
+- Preliminary matters, proposed agenda.
+- Updating overview:
+    - GitHub project board (link in agenda above)
+    - component-focused encoding etc. (link in agenda above)
+    - master issues/PRs (link in agenda above)
+    - Implementation of RFC 2119/8174 but without using "not/NOT"
+- Philippe: shared the project board
+    - PR 373 re RFC 2119/8174 – good comments, but many unrelated to the narrow focus
+    - Eventually will be parsed into separate narrow issues → narrow PRs
+    - Contributions to individual items would be very helpful
+    - Philippe walked us briefly through the board and the "encoding" gSheet, described how the logistics of the process could work, and created and fleshed out some new items → new focused issues, illustrating the process.  Goal: a simple PR.  Quick view of the scheme-focused PR 361.
+    - Hope to finalize core spec updating by the end of March ideally (and earlier if possible).
+    - Martin: would like to take on one of these – "Clarify spec for version" (issue 380).  Philippe: inviting Martin to join the project; done.
+    - Jan: will take on the subpath component – "Clarify spec for subpath" (issue 379).
+- Philippe: Brief recap.  A JSON Schema is a goal going forward.
+- The meeting was adjourned.


### PR DESCRIPTION
Reference: https://github.com/package-url/purl-spec/issues/384

- Also added a new 'meetings' folder for the minutes.