### PR TITLE
fix(test-suite-data): Fix subpath tests

### DIFF
--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -56,7 +56,7 @@
     "name": "genproto",
     "version": "abcdedf",
     "qualifiers": null,
-    "subpath": "googleapis/../api/annotations",
+    "subpath": "googleapis/api/annotations",
     "is_invalid": false
   },
   {
@@ -68,7 +68,7 @@
     "name": "genproto",
     "version": "abcdedf",
     "qualifiers": null,
-    "subpath": "googleapis/./api/annotations",
+    "subpath": "googleapis/api/annotations",
     "is_invalid": false
   },
   {


### PR DESCRIPTION
The purls are valid as input, but the dots should be dropped from the canonical output.

The test should list the canonical component for `subpath`, not the input component.