### PR TITLE
Add 2025-03-05 PURL community meetings minutes #384

### DIFF
--- a/meetings/2025-03-05.md
+++ b/meetings/2025-03-05.md
@@ -1,0 +1,53 @@
+# Agenda for the PURL community meeting on 2025-03-05
+
+- **Host**: Remote
+- **Dates and times**:
+    - 17:00 to 17:30 UTC
+    - 18:00 to 18:30 CEST (Europe/Brussels)
+    - 12:00 to 12:30 EST (America/New_York)
+    - 09:00 to 09:30 PST (America/Los Angeles)
+    - 02:00 to 02:30 JST (Tokyo, Japan)
+
+- **Attendee information**:
+  - https://meet.google.com/ydj-qwbs-iiv
+  - [Meeting invite](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=MWliM3RyZXRpdmI4NXFoYXR1MzRkdmg0a3ZfMjAyNTAxMjJUMTcwMDAwWiBjX2Q4YjE1NDIwZGZmMTdiNzk1OWUyOWE1MWFlMzI0MDk1MWNiZTM4ZGIxZGFlNDU5NzJhODVjOWE3MTEyMDQyMDVAZw&tmsrc=c_d8b15420dff17b7959e29a51ae3240951cbe38db1dae45972a85c9a711204205%40group.calendar.google.com&scp=ALL)
+
+## Agenda items
+- Opening of the meeting and welcome
+- Meetings will follow the Ecma TC54 Code of Conduct https://github.com/Ecma-TC54/tg2/blob/main/CODE_OF_CONDUCT.md
+- Minutes of the 2025-02-19 meeting -- https://github.com/package-url/purl-spec/blob/master/meetings/2025-02-19.md
+- Overview of current core spec updating
+    - GitHub project board https://github.com/orgs/package-url/projects/1/views/1
+    - Component-focused encoding etc.  https://docs.google.com/spreadsheets/d/1biOCUY4eCqQaYmfGDHVrASV9igYEzct6
+    - Open issues/PRs https://docs.google.com/spreadsheets/d/1H2QAcADLaMNgcR5BMK7bQxzH5D3X-SdO
+
+## Attendees
+- Philippe Ombredanne, PURL, AboutCode, TC54-TG2 convener
+- John Horan, AboutCode
+- Michael Herzog, AboutCode
+- David Walluck
+- Immanuel Kunz, Fraunhofer AISEC
+- Joshua Kugler, Adobe
+- Jaime Rodríguez-Guerra, Quansight
+- Steve Springett, OWASP Foundation / ServiceNow
+
+
+## Notes
+- Meeting minutes are being kept and will be published, but the meeting is not being recorded.
+- Our code of conduct (link in agenda above) applies to this meeting.
+- Introductions.
+- Agenda items:
+    - David: general info plus Java focus
+    - Immanuel: version range
+    - John: qualifiers/character encoding update
+    - Joshua: general info plus a spec ambiguity they're working through
+    - Michael: nothing in particular
+    - Philippe: qualifiers PR
+    - Jaime: follow-up from last meeting
+        - Reply to https://github.com/package-url/purl-spec/issues/386#issuecomment-2636210323
+        - https://github.com/package-url/purl-spec/issues/222
+    - Steve: nothing in particular
+- Philippe: Let's start with Immanuel's PR: https://github.com/package-url/purl-spec/pull/343 .  Discussion followed on this and several issues from other participants.
+- Philippe: qualifiers.  Discussion of percent-encoding, need for clarity.  Philippe: should be simple and clear and expressed in the "Character encoding" section.
+- Philippe: Let's turn to Steve's JSON Schema PR.  Steve: The PR includes markdown automatically generated from the JSON.  Philippe: `.rst` vs `.md` but that's minor.  Explored examples.  Steve: normalization is also an important issue and there are behaviors/definitions that are incorrect (e.g., upper vs lower casing).  Joshua: Invalid names can be/are an issue.  Philippe: need to avoid changing rules rather than simply clarifying the spec.  Steve: if we move forward with describing types with JSON, there are issues to address.  Philippe and Steve discussed.  Brief discussion of YAML.  Steve: looking for an answer on `.md` vs. `.rst`.
+- The meeting was adjourned.


### PR DESCRIPTION
This replaces the prior PR, which inadvertently contained unrelated purl-spec-update edits.

Reference: https://github.com/package-url/purl-spec/issues/384