### PR TITLE
Fix colon encoding in tests again

### DIFF
--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -109,8 +109,8 @@
   },
   {
     "description": "docker uses qualifiers and hash image id as versions",
-    "purl": "pkg:docker/customer/dockerimage@sha256%3A244fd47e07d1004f0aed9c?repository_url=gcr.io",
-    "canonical_purl": "pkg:docker/customer/dockerimage@sha256%3A244fd47e07d1004f0aed9c?repository_url=gcr.io",
+    "purl": "pkg:docker/customer/dockerimage@sha256:244fd47e07d1004f0aed9c?repository_url=gcr.io",
+    "canonical_purl": "pkg:docker/customer/dockerimage@sha256:244fd47e07d1004f0aed9c?repository_url=gcr.io",
     "type": "docker",
     "namespace": "customer",
     "name": "dockerimage",


### PR DESCRIPTION
About colons, the spec says:

https://github.com/package-url/purl-spec/blob/7f7e82f73c38a4a339f88abf1f2aa031e9c7af23/PURL-SPECIFICATION.rst?plain=1#L228-L232

Therefore, the colon should not be encoded. I've read #364 and I can't understand the reasoning for changing the unencoded colon to be encoded. #364 also quotes the spec and references another issue, contradicting its own implementation.

9/14 implementations agree that this colon is not to be encoded.