### PR TITLE
Add new PURL type: 'github-release'

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -317,7 +317,7 @@ github-release
 - Examples::
 
       pkg:github-release/cli/cli@v2.67.0
-      pkg:github-release/foo/bar@v1.0.0?repository_url=https://foobar.ghe.com
+      pkg:github-release/foo/bar@v1.0.0?repository_url=https:%2F%2Ffoobar.ghe.com
       pkg:github-release/foo/bar@v1.0.0?file_name=bin-linux.tgz&checksum=sha256:deadbeef
 
 golang

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -311,12 +311,14 @@ github-release
   is assumed as the default.
 - Qualifier ``file_name``: Selects a named (case sensitive) asset contained 
   within the release (optional).
+- Qualifier ``checksum``: Checksum for the release asset (optional). Must be
+  in the form of `lowercase_algorithm:hex_encoded_lowercase_value`.
 
 - Examples::
 
       pkg:github-release/cli/cli@v2.67.0
       pkg:github-release/foo/bar@v1.0.0?repository_url=https://foobar.ghe.com
-      pkg:github-release/foo/bar@v1.0.0?file_name=bin-linux.tgz
+      pkg:github-release/foo/bar@v1.0.0?file_name=bin-linux.tgz&checksum:sha256:deadbeef
 
 golang
 ------

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -318,7 +318,7 @@ github-release
 
       pkg:github-release/cli/cli@v2.67.0
       pkg:github-release/foo/bar@v1.0.0?repository_url=https://foobar.ghe.com
-      pkg:github-release/foo/bar@v1.0.0?file_name=bin-linux.tgz&checksum:sha256:deadbeef
+      pkg:github-release/foo/bar@v1.0.0?file_name=bin-linux.tgz&checksum=sha256:deadbeef
 
 golang
 ------

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -297,6 +297,24 @@ github
       pkg:github/package-url/purl-spec@244fd47e07d1004
       pkg:github/package-url/purl-spec@244fd47e07d1004#everybody/loves/dogs
 
+github-release
+--------------
+``github-release`` for GitHub releases:
+
+- ``namespace``: The GitHub user or organization. It is not case sensitive and
+  must be lowercased.
+- ``name``: The GitHub repository name. It is not case sensitive and must be
+  lowercased.
+- ``version``: The release version. It is required and is case sensitive.
+- Qualifier ``repository_url``: GitHub server hosting the release (optional).
+  Useful in case a private server is used. If omitted, ``https://github.com``
+  is assumed as the default.
+
+- Examples::
+
+      pkg:github-release/cli/cli@v2.67.0
+      pkg:github-release/foo/bar@v1.0.0?repository_url=https://foobar.ghe.com
+
 golang
 ------
 ``golang`` for Go packages:

--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -309,11 +309,14 @@ github-release
 - Qualifier ``repository_url``: GitHub server hosting the release (optional).
   Useful in case a private server is used. If omitted, ``https://github.com``
   is assumed as the default.
+- Qualifier ``file_name``: Selects a named (case sensitive) asset contained 
+  within the release (optional).
 
 - Examples::
 
       pkg:github-release/cli/cli@v2.67.0
       pkg:github-release/foo/bar@v1.0.0?repository_url=https://foobar.ghe.com
+      pkg:github-release/foo/bar@v1.0.0?file_name=bin-linux.tgz
 
 golang
 ------

--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -706,5 +706,17 @@
     "qualifiers": null,
     "subpath": null,
     "is_invalid": true
+  },
+  {
+    "description": "github-release valid name",
+    "purl": "pkg:GitHub-Release/foo/Bar@v1.0.1?repository_url=https://acme.ghe.com&file_name=bin-linux.tgz&checksum=sha256:ff537afd5996cb67a319d6b0d3e65a330480068398a90bd81ea823a0566512c8",
+    "canonical_purl": "pkg:github-release/foo/bar@v1.0.1?repository_url=https://acme.ghe.com&file_name=bin-linux.tgz&checksum=sha256:ff537afd5996cb67a319d6b0d3e65a330480068398a90bd81ea823a0566512c8",
+    "type": "github-release",
+    "namespace": "foo",
+    "name": "bar",
+    "version": "v1.0.1",
+    "qualifiers": {"repository_url": "https://acme.ghe.com", "file_name": "bin-linux.tgz", "checksum": "sha256:ff537afd5996cb67a319d6b0d3e65a330480068398a90bd81ea823a0566512c8" },
+    "subpath": null,
+    "is_invalid": false
   }
 ]

--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -710,7 +710,7 @@
   {
     "description": "github-release valid name",
     "purl": "pkg:GitHub-Release/foo/Bar@v1.0.1?repository_url=https://acme.ghe.com&file_name=bin-linux.tgz&checksum=sha256:ff537afd5996cb67a319d6b0d3e65a330480068398a90bd81ea823a0566512c8",
-    "canonical_purl": "pkg:github-release/foo/bar@v1.0.1?repository_url=https://acme.ghe.com&file_name=bin-linux.tgz&checksum=sha256:ff537afd5996cb67a319d6b0d3e65a330480068398a90bd81ea823a0566512c8",
+    "canonical_purl": "pkg:github-release/foo/bar@v1.0.1?repository_url=https:%2F%2Facme.ghe.com&file_name=bin-linux.tgz&checksum=sha256:ff537afd5996cb67a319d6b0d3e65a330480068398a90bd81ea823a0566512c8",
     "type": "github-release",
     "namespace": "foo",
     "name": "bar",


### PR DESCRIPTION
Per: #299 

Introduces a new `github-release` package type for identifying specific [GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases).

There is some overlap here with the existing `github` package type -- in theory you can point to a GitHub release today with a `github` package type be identifying the release's tag:

```
pkg:github/foo/bar@v1.0.0
```

However, there may come a time when GitHub releases are decoupled from git tags and it would be helpful to have a way to disambiguate between a plain ol' GitHub repository tag and a named GitHub Release:

```
pkg:github-release/foo/bar@v1.0.0
```

The most immediate use case for this is in the context of in-toto [release predicates](https://github.com/in-toto/attestation/blob/main/spec/predicates/release.md#schema) where we need to be able to identify a specific GitHub release using a purl.
