### PR TITLE
Updated CPAN type spec

### DIFF
--- a/tests/types/cpan-test.json
+++ b/tests/types/cpan-test.json
@@ -2,7 +2,7 @@
   "$schema": "https://packageurl.org/schemas/purl-test.schema-1.0.json",
   "tests": [
     {
-      "description": "cpan distribution name are case sensitive. Rountrip an input purl to canonical.",
+      "description": "CPAN distribution name are case sensitive. Rountrip an input purl to canonical.",
       "test_group": "advanced",
       "test_type": "roundtrip",
       "input": "pkg:cpan/DROLSKY/DateTime@1.55",
@@ -11,7 +11,7 @@
       "expected_failure_reason": null
     },
     {
-      "description": "cpan distribution name are case sensitive",
+      "description": "CPAN distribution name are case sensitive",
       "test_group": "base",
       "test_type": "parse",
       "input": "pkg:cpan/DROLSKY/DateTime@1.55",
@@ -27,7 +27,7 @@
       "expected_failure_reason": null
     },
     {
-      "description": "cpan distribution name are case sensitive. Rountrip a canonical input to canonical output.",
+      "description": "CPAN distribution name are case sensitive. Rountrip a canonical input to canonical output.",
       "test_group": "base",
       "test_type": "roundtrip",
       "input": "pkg:cpan/DROLSKY/DateTime@1.55",
@@ -36,7 +36,7 @@
       "expected_failure_reason": null
     },
     {
-      "description": "cpan distribution name are case sensitive",
+      "description": "CPAN distribution name are case sensitive",
       "test_group": "base",
       "test_type": "build",
       "input": {
@@ -51,76 +51,9 @@
       "expected_failure": false,
       "expected_failure_reason": null
     },
+
     {
-      "description": "cpan module name are case sensitive. Rountrip an input purl to canonical.",
-      "test_group": "advanced",
-      "test_type": "roundtrip",
-      "input": "pkg:cpan/URI::PackageURL@2.11",
-      "expected_output": "pkg:cpan/URI::PackageURL@2.11",
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "cpan module name are case sensitive",
-      "test_group": "base",
-      "test_type": "parse",
-      "input": "pkg:cpan/URI::PackageURL@2.11",
-      "expected_output": {
-        "type": "cpan",
-        "namespace": null,
-        "name": "URI::PackageURL",
-        "version": "2.11",
-        "qualifiers": null,
-        "subpath": null
-      },
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "cpan module name are case sensitive. Rountrip a canonical input to canonical output.",
-      "test_group": "base",
-      "test_type": "roundtrip",
-      "input": "pkg:cpan/URI::PackageURL@2.11",
-      "expected_output": "pkg:cpan/URI::PackageURL@2.11",
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "cpan module name are case sensitive",
-      "test_group": "base",
-      "test_type": "build",
-      "input": {
-        "type": "cpan",
-        "namespace": null,
-        "name": "URI::PackageURL",
-        "version": "2.11",
-        "qualifiers": null,
-        "subpath": null
-      },
-      "expected_output": "pkg:cpan/URI::PackageURL@2.11",
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "cpan module name like distribution name",
-      "test_group": "base",
-      "test_type": "parse",
-      "input": "pkg:cpan/Perl-Version@1.013",
-      "expected_output": null,
-      "expected_failure": true,
-      "expected_failure_reason": "Should fail to parse a PURL from invalid purl input"
-    },
-    {
-      "description": "cpan module name like distribution name",
-      "test_group": "base",
-      "test_type": "parse",
-      "input": "pkg:cpan/Perl-Version@1.013",
-      "expected_output": null,
-      "expected_failure": true,
-      "expected_failure_reason": "Should fail to parse a PURL from invalid canonical purl input"
-    },
-    {
-      "description": "cpan module name like distribution name",
+      "description": "CPAN distribution without author",
       "test_group": "base",
       "test_type": "build",
       "input": {
@@ -136,16 +69,16 @@
       "expected_failure_reason": "Should fail to build a PURL from invalid input components"
     },
     {
-      "description": "cpan distribution name like module name",
+      "description": "CPAN with just the module name and version",
       "test_group": "base",
       "test_type": "parse",
-      "input": "pkg:cpan/GDT/URI::PackageURL@2.11",
+      "input": "pkg:cpan/LWP::UserAgent@6.7.6",
       "expected_output": null,
       "expected_failure": true,
       "expected_failure_reason": "Should fail to parse a PURL from invalid purl input"
     },
     {
-      "description": "cpan distribution name like module name",
+      "description": "CPAN distribution name as module name",
       "test_group": "base",
       "test_type": "parse",
       "input": "pkg:cpan/GDT/URI::PackageURL",
@@ -154,7 +87,7 @@
       "expected_failure_reason": "Should fail to parse a PURL from invalid canonical purl input"
     },
     {
-      "description": "cpan distribution name like module name",
+      "description": "CPAN distribution name like module name",
       "test_group": "base",
       "test_type": "build",
       "input": {
@@ -170,163 +103,6 @@
       "expected_failure_reason": "Should fail to build a PURL from invalid input components"
     },
     {
-      "description": "cpan valid module name. Rountrip an input purl to canonical.",
-      "test_group": "advanced",
-      "test_type": "roundtrip",
-      "input": "pkg:cpan/DateTime@1.55",
-      "expected_output": "pkg:cpan/DateTime@1.55",
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "cpan valid module name",
-      "test_group": "base",
-      "test_type": "parse",
-      "input": "pkg:cpan/DateTime@1.55",
-      "expected_output": {
-        "type": "cpan",
-        "namespace": null,
-        "name": "DateTime",
-        "version": "1.55",
-        "qualifiers": null,
-        "subpath": null
-      },
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "cpan valid module name. Rountrip a canonical input to canonical output.",
-      "test_group": "base",
-      "test_type": "roundtrip",
-      "input": "pkg:cpan/DateTime@1.55",
-      "expected_output": "pkg:cpan/DateTime@1.55",
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "cpan valid module name",
-      "test_group": "base",
-      "test_type": "build",
-      "input": {
-        "type": "cpan",
-        "namespace": null,
-        "name": "DateTime",
-        "version": "1.55",
-        "qualifiers": null,
-        "subpath": null
-      },
-      "expected_output": "pkg:cpan/DateTime@1.55",
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "cpan valid module name without version. Rountrip an input purl to canonical.",
-      "test_group": "advanced",
-      "test_type": "roundtrip",
-      "input": "pkg:cpan/URI",
-      "expected_output": "pkg:cpan/URI",
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "cpan valid module name without version",
-      "test_group": "base",
-      "test_type": "parse",
-      "input": "pkg:cpan/URI",
-      "expected_output": {
-        "type": "cpan",
-        "namespace": null,
-        "name": "URI",
-        "version": null,
-        "qualifiers": null,
-        "subpath": null
-      },
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "cpan valid module name without version. Rountrip a canonical input to canonical output.",
-      "test_group": "base",
-      "test_type": "roundtrip",
-      "input": "pkg:cpan/URI",
-      "expected_output": "pkg:cpan/URI",
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "cpan valid module name without version",
-      "test_group": "base",
-      "test_type": "build",
-      "input": {
-        "type": "cpan",
-        "namespace": null,
-        "name": "URI",
-        "version": null,
-        "qualifiers": null,
-        "subpath": null
-      },
-      "expected_output": "pkg:cpan/URI",
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "Parse test for <class 'type'> PURL",
-      "test_group": "base",
-      "test_type": "parse",
-      "input": "pkg:cpan/Perl::Version@1.013",
-      "expected_output": {
-        "type": "cpan",
-        "namespace": null,
-        "name": "perl::Version",
-        "version": "1.013",
-        "qualifiers": null,
-        "subpath": null
-      },
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "Rountrip test for <class 'type'> PURL",
-      "test_group": "base",
-      "test_type": "roundtrip",
-      "input": "pkg:cpan/Perl::Version@1.013",
-      "expected_output": "pkg:cpan/Perl::Version@1.013",
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "Build test  for <class 'type'> PURL",
-      "test_group": "base",
-      "test_type": "build",
-      "input": {
-        "type": "cpan",
-        "namespace": null,
-        "name": "perl::Version",
-        "version": "1.013",
-        "qualifiers": null,
-        "subpath": null
-      },
-      "expected_output": "pkg:cpan/Perl::Version@1.013",
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "Parse test for <class 'type'> PURL",
-      "test_group": "base",
-      "test_type": "parse",
-      "input": "pkg:cpan/DROLSKY/DateTime@1.55",
-      "expected_output": {
-        "type": "cpan",
-        "namespace": "DROLSKY",
-        "name": "DateTime",
-        "version": "1.55",
-        "qualifiers": null,
-        "subpath": null
-      },
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
       "description": "Rountrip test for <class 'type'> PURL",
       "test_group": "base",
       "test_type": "roundtrip",
@@ -336,7 +112,7 @@
       "expected_failure_reason": null
     },
     {
-      "description": "Build test  for <class 'type'> PURL",
+      "description": "Build test for <class 'type'> PURL",
       "test_group": "base",
       "test_type": "build",
       "input": {
@@ -348,47 +124,6 @@
         "subpath": null
       },
       "expected_output": "pkg:cpan/DROLSKY/DateTime@1.55",
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "Parse test for <class 'type'> PURL",
-      "test_group": "base",
-      "test_type": "parse",
-      "input": "pkg:cpan/DateTime@1.55",
-      "expected_output": {
-        "type": "cpan",
-        "namespace": null,
-        "name": "DateTime",
-        "version": "1.55",
-        "qualifiers": null,
-        "subpath": null
-      },
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "Rountrip test for <class 'type'> PURL",
-      "test_group": "base",
-      "test_type": "roundtrip",
-      "input": "pkg:cpan/DateTime@1.55",
-      "expected_output": "pkg:cpan/DateTime@1.55",
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "Build test  for <class 'type'> PURL",
-      "test_group": "base",
-      "test_type": "build",
-      "input": {
-        "type": "cpan",
-        "namespace": null,
-        "name": "DateTime",
-        "version": "1.55",
-        "qualifiers": null,
-        "subpath": null
-      },
-      "expected_output": "pkg:cpan/DateTime@1.55",
       "expected_failure": false,
       "expected_failure_reason": null
     },
@@ -418,7 +153,7 @@
       "expected_failure_reason": null
     },
     {
-      "description": "Build test  for <class 'type'> PURL",
+      "description": "Build test for <class 'type'> PURL",
       "test_group": "base",
       "test_type": "build",
       "input": {
@@ -437,47 +172,6 @@
       "description": "Parse test for <class 'type'> PURL",
       "test_group": "base",
       "test_type": "parse",
-      "input": "pkg:cpan/LWP::UserAgent",
-      "expected_output": {
-        "type": "cpan",
-        "namespace": null,
-        "name": "lwp::UserAgent",
-        "version": null,
-        "qualifiers": null,
-        "subpath": null
-      },
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "Rountrip test for <class 'type'> PURL",
-      "test_group": "base",
-      "test_type": "roundtrip",
-      "input": "pkg:cpan/LWP::UserAgent",
-      "expected_output": "pkg:cpan/LWP::UserAgent",
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "Build test  for <class 'type'> PURL",
-      "test_group": "base",
-      "test_type": "build",
-      "input": {
-        "type": "cpan",
-        "namespace": null,
-        "name": "lwp::UserAgent",
-        "version": null,
-        "qualifiers": null,
-        "subpath": null
-      },
-      "expected_output": "pkg:cpan/LWP::UserAgent",
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "Parse test for <class 'type'> PURL",
-      "test_group": "base",
-      "test_type": "parse",
       "input": "pkg:cpan/OALDERS/libwww-perl@6.76",
       "expected_output": {
         "type": "cpan",
@@ -500,7 +194,7 @@
       "expected_failure_reason": null
     },
     {
-      "description": "Build test  for <class 'type'> PURL",
+      "description": "Build test for <class 'type'> PURL",
       "test_group": "base",
       "test_type": "build",
       "input": {
@@ -516,43 +210,47 @@
       "expected_failure_reason": null
     },
     {
+      "description": "Rountrip test for <class 'type'> PURL",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:cpan/DROLSKY/DateTime@1.55?repository_url=backpan.perl.org",
+      "expected_output": "pkg:cpan/DROLSKY/DateTime@1.55?repository_url=backpan.perl.org",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
       "description": "Parse test for <class 'type'> PURL",
       "test_group": "base",
       "test_type": "parse",
-      "input": "pkg:cpan/URI",
+      "input": "pkg:cpan/DROLSKY/DateTime@1.55?repository_url=backpan.perl.org",
       "expected_output": {
         "type": "cpan",
-        "namespace": null,
-        "name": "URI",
-        "version": null,
-        "qualifiers": null,
+        "namespace": "DROLSKY",
+        "name": "DateTime",
+        "version": "1.55",
+        "qualifiers": {
+          "repository_url":"backpan.perl.org"
+        },
         "subpath": null
       },
       "expected_failure": false,
       "expected_failure_reason": null
     },
     {
-      "description": "Rountrip test for <class 'type'> PURL",
-      "test_group": "base",
-      "test_type": "roundtrip",
-      "input": "pkg:cpan/URI",
-      "expected_output": "pkg:cpan/URI",
-      "expected_failure": false,
-      "expected_failure_reason": null
-    },
-    {
-      "description": "Build test  for <class 'type'> PURL",
+      "description": "Build test for <class 'type'> PURL",
       "test_group": "base",
       "test_type": "build",
       "input": {
         "type": "cpan",
-        "namespace": null,
-        "name": "URI",
-        "version": null,
-        "qualifiers": null,
+        "namespace": "DROLSKY",
+        "name": "DateTime",
+        "version": "1.55",
+        "qualifiers": {
+          "repository_url":"backpan.perl.org"
+        },
         "subpath": null
       },
-      "expected_output": "pkg:cpan/URI",
+      "expected_output": "pkg:cpan/DROLSKY/DateTime@1.55?repository_url=backpan.perl.org",
       "expected_failure": false,
       "expected_failure_reason": null
     }

--- a/types-doc/cpan-definition.md
+++ b/types-doc/cpan-definition.md
@@ -4,7 +4,7 @@ Do not manually edit this file. Edit the JSON type definition instead. -->
 # PURL Type Definition: cpan
 
 - **Type Name:** CPAN
-- **Description:** CPAN Perl packages
+- **Description:** Perl package distributions published on CPAN
 - **Schema ID:** `https://packageurl.org/types/cpan-definition.json`
 
 ## PURL Syntax
@@ -20,21 +20,20 @@ The structure of a PURL for this package type is:
 
 ## Namespace definition
 
-- **Requirement:** Optional
-- **Note:** `- To refer to a CPAN distribution name, the namespace MUST be present. In this case, the namespace is the CPAN id of the author/publisher. It MUST be written uppercase, followed by the distribution name in the name component. A distribution name MUST NOT contain the string ::.
-- To refer to a CPAN module, the namespace MUST be absent. The module name MAY contain zero or more :: strings, and the module name MUST NOT contain a -
-`
+- **Requirement:** Required
+- **Native Label:** CPAN ID of the author/publisher
+- **Note:** `It MUST be written uppercase and is required.`
 
 ## Name definition
 
 - **Case Sensitive:** Yes
-- **Native Label:** module or distribution name
-- **Note:** `The name is the module or distribution name and is case sensitive.`
+- **Native Label:** distribution name
+- **Note:** `The name is the distribution name and is case sensitive. A distribution name MUST NOT contain the string '::'`
 
 ## Version definition
 
 - **Native Label:** version
-- **Note:** `The version is the module or distribution version.`
+- **Note:** `The version is the distribution version.`
 
 ## Qualifiers Definition
 
@@ -47,10 +46,6 @@ The structure of a PURL for this package type is:
 
 ## Examples
 
-- `pkg:cpan/Perl::Version@1.013`
-- `pkg:cpan/DROLSKY/DateTime@1.55`
-- `pkg:cpan/DateTime@1.55`
 - `pkg:cpan/GDT/URI-PackageURL`
-- `pkg:cpan/LWP::UserAgent`
 - `pkg:cpan/OALDERS/libwww-perl@6.76`
-- `pkg:cpan/URI`
+- `pkg:cpan/DROLSKY/DateTime@1.55?repository_url=backpan.perl.org`

--- a/types/cpan-definition.json
+++ b/types/cpan-definition.json
@@ -3,50 +3,51 @@
   "$id": "https://packageurl.org/types/cpan-definition.json",
   "type": "cpan",
   "type_name": "CPAN",
-  "description": "CPAN Perl packages",
+  "description": "Perl package distributions published on CPAN",
   "repository": {
     "use_repository": true,
     "default_repository_url": "https://www.cpan.org/"
   },
   "namespace_definition": {
-    "requirement": "optional",
-    "note": "- To refer to a CPAN distribution name, the namespace MUST be present. In this case, the namespace is the CPAN id of the author/publisher. It MUST be written uppercase, followed by the distribution name in the name component. A distribution name MUST NOT contain the string ::.\n- To refer to a CPAN module, the namespace MUST be absent. The module name MAY contain zero or more :: strings, and the module name MUST NOT contain a -\n"
+    "requirement": "required",
+    "native_name": "CPAN ID of the author/publisher",
+    "note": "It MUST be written uppercase and is required."
   },
   "name_definition": {
     "case_sensitive": true,
-    "native_name": "module or distribution name",
-    "note": "The name is the module or distribution name and is case sensitive."
+    "native_name": "distribution name",
+    "note": "The name is the distribution name and is case sensitive. A distribution name MUST NOT contain the string '::'"
   },
   "version_definition": {
-    "note": "The version is the module or distribution version.",
+    "note": "The version is the distribution version.",
     "native_name": "version"
   },
   "qualifiers_definition": [
     {
       "key": "repository_url",
+      "requirement": "optional",
       "description": "CPAN/MetaCPAN/BackPAN/DarkPAN repository base URL"
     },
     {
       "key": "download_url",
+      "requirement": "optional",
       "description": "URL of package or distribution"
     },
     {
       "key": "vcs_url",
+      "requirement": "optional",
       "description": "extra URL for a package version control system"
     },
     {
       "key": "ext",
+      "requirement": "optional",
       "description": "file extension",
       "default_value": "tar.gz"
     }
   ],
   "examples": [
-    "pkg:cpan/Perl::Version@1.013",
-    "pkg:cpan/DROLSKY/DateTime@1.55",
-    "pkg:cpan/DateTime@1.55",
     "pkg:cpan/GDT/URI-PackageURL",
-    "pkg:cpan/LWP::UserAgent",
     "pkg:cpan/OALDERS/libwww-perl@6.76",
-    "pkg:cpan/URI"
+    "pkg:cpan/DROLSKY/DateTime@1.55?repository_url=backpan.perl.org"
   ]
 }


### PR DESCRIPTION
This PR is for the new version of the purl-type CPAN specification and includes new updated tests.

https://github.com/giterlizzi/perl-URI-PackageURL/issues/8

In brief, this PR confirms the rules for generating a PURL string for CPAN.

Previously it was possible to create PURL strings in two ways:
- author (namespace) and distribution (name)
- module (name component).

Using only the module could create ambiguity, because in CPAN a distribution can have several authors (and co-authors) over time and does not allow precise identification of the artifact.

It was clarified that the author of the "distribution" is mandatory, allowing an artifact and its URL to be identified along with its version.

```console
$ purl-tool pkg:cpan/GDT/URI-PackageURL@2.22 --download-url
https://www.cpan.org/authors/id/G/GD/GDT/URI-PackageURL-2.22.tar.gz
```