### PR TITLE
Add minutes of 2025-03-19 PURL community meeting #384

### DIFF
--- a/meetings/2025-03-19.md
+++ b/meetings/2025-03-19.md
@@ -1,0 +1,61 @@
+# Agenda for the PURL community meeting on 2025-03-19
+
+- **Host**: Remote
+- **Dates and times**:
+    - 16:00 to 16:30 UTC
+    - 17:00 to 17:30 CET (Europe/Brussels)
+    - 12:00 to 12:30 EDT (America/New_York)
+    - 09:00 to 09:30 PDT (America/Los Angeles)
+    - 01:00 to 01:30 JST (Tokyo, Japan)
+
+- **Attendee information**:
+  - https://meet.google.com/ydj-qwbs-iiv
+  - [Meeting invite](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=MWliM3RyZXRpdmI4NXFoYXR1MzRkdmg0a3ZfMjAyNTAxMjJUMTcwMDAwWiBjX2Q4YjE1NDIwZGZmMTdiNzk1OWUyOWE1MWFlMzI0MDk1MWNiZTM4ZGIxZGFlNDU5NzJhODVjOWE3MTEyMDQyMDVAZw&tmsrc=c_d8b15420dff17b7959e29a51ae3240951cbe38db1dae45972a85c9a711204205%40group.calendar.google.com&scp=ALL)
+
+## Agenda items
+- Opening of the meeting and welcome
+- Meetings will follow the Ecma TC54 Code of Conduct https://github.com/Ecma-TC54/tg2/blob/main/CODE_OF_CONDUCT.md
+- Minutes of the 2025-03-05 meeting -- https://github.com/package-url/purl-spec/blob/master/meetings/2025-03-05.md
+- Overview of current core spec updating
+    - GitHub project board https://github.com/orgs/package-url/projects/1/views/1
+    - Component-focused encoding etc.  https://docs.google.com/spreadsheets/d/1biOCUY4eCqQaYmfGDHVrASV9igYEzct6
+    - Open issues/PRs https://docs.google.com/spreadsheets/d/1H2QAcADLaMNgcR5BMK7bQxzH5D3X-SdO
+
+## Attendees
+- Philippe Ombredanne, PURL, AboutCode, TC54-TG2 convener
+- John Horan, AboutCode
+- David Walluck
+- Joshua Kugler, Adobe
+- Jaime Rodríguez-Guerra, Quansight
+- Martin Prpic, Red Hat
+- Jan Kowalleck, Sovereign Tech Agency
+- Immanuel Kunz, Fraunhofer AISEC
+
+
+## Notes
+- Meeting minutes are being kept and will be published, but the meeting is not being recorded.
+- Our code of conduct (link in agenda above) applies to this meeting.
+- Introductions.
+- Agenda items:
+    - Joshua: nothing in particular
+    - Jan: various topics
+    - Martin: qualifiers and percent encoding
+    - David: several topics; general concern: the Java implementation and its test suite.
+    - John: qualifiers and percent encoding – PR 398 (https://github.com/package-url/purl-spec/pull/398).
+    - Jaime:
+        - discuss #386 (https://github.com/package-url/purl-spec/issues/386) + #362 (https://github.com/package-url/purl-spec/issues/362) (similar proposals about "requirements PURLs"),
+        - and also #222 (https://github.com/package-url/purl-spec/issues/222) (pkg:abstract/* PURLs)
+- Philippe: Let's look at PR 398 (https://github.com/package-url/purl-spec/pull/398).
+    - Character encoding section.
+    - Discussion re permitted characters in a PURL/purl string.  Some version schemes (e.g., semver) use '+'.  (See https://semver.org/spec/v2.0.0.html#spec-item-10.)
+    - Many of the participants: we can and should simplify the encoding requirements.  ':', '@' and many other characters present some challenges.
+    - Extensive discussion re restructuring character encoding to define default encoding rule(s).
+    - The "How to parse" section is also implicated by the encoding rules and rewriting.
+    - Phillipe and John to discuss and prepare a crisp proposal for the group's consideration and feedback.
+    - Philippe: RFC 3986 is invaluable but at times extremely complex.
+- Also discussed splitting the test suite between core and types – PR 428 (https://github.com/package-url/purl-spec/pull/428).  Jan and others: we need flexibility in how we use the various objects in the test suite.
+- Jaime: Re PEP 725 (https://peps.python.org/pep-0725/) – we need something that is ecosystem-agnostic –- single source of truth.  Vendored dependencies present a challenge.
+- Discussion of versions ranges.  See, e.g., https://github.com/package-url/purl-spec/issues/362 and https://github.com/package-url/purl-spec/issues/386.
+- PR 422 – Philippe understands this can be useful in certain corner cases.
+- Issue 222 – Jaime asked Philippe to consider abstract PURL types.
+- The meeting was adjourned.


### PR DESCRIPTION
Added 2025-03-19 meeting minutes.

Reference: https://github.com/package-url/purl-spec/issues/384