### PR TITLE
Clarification regarding the version in the oci type

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -484,7 +484,7 @@ including container images built by Docker and others:
   last fragment of the repository name. For example if the repository
   name is ``library/debian`` then the ``name`` is ``debian``.
 - The ``version`` is the ``sha256:hex_encoded_lowercase_digest`` of the
-  artifact and is required to uniquely identify the artifact.
+  artifact and is used to uniquely identify the artifact.
 - Optional qualifiers may include:
 
   - ``arch``: key for a package architecture, when relevant.


### PR DESCRIPTION
Based on the https://github.com/package-url/purl-spec# the `version` is an optional filed:  
`version: the version of the package. Optional.`
When on the `oci` purl type description there is information that it's required parameter, which can cause a confusion. 

Version should stay as optional field because it covers specific use case when the version of the component is unknown.