### PR TITLE
PURL add well-known qualifier `vers`

### DIFF
--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -420,9 +420,9 @@ download URL, VCS URL or checksums in an API, database or web form.
 With this warning, the known ``key`` and ``value`` defined here are valid for use in
 all package types:
 
-- ``vers`` is a replacement for the component ``version``.
-  This allows to define a version range, instead of a single version.
-  The value of this qualifier MUST comply to `version range spec <VERSION-RANGE-SPEC.rst>`_.
+- ``vers`` allows to define a version range, instead of a single version.
+  The value MUST comply to `version range spec <VERSION-RANGE-SPEC.rst>`_.
+  This qualifier is mutual exclusive to the component ``version``!
 
 - ``repository_url`` is an extra URL for an alternative, non-default package
   repository or registry. When a package does not come from the default public

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -420,9 +420,9 @@ download URL, VCS URL or checksums in an API, database or web form.
 With this warning, the known ``key`` and ``value`` defined here are valid for use in
 all package types:
 
-- ``vers`` allows to define a version range, instead of a single version.
-  The value MUST comply to `version range spec <VERSION-RANGE-SPEC.rst>`_.
-  This qualifier is mutual exclusive to the component ``version``!
+- ``vers`` allows the specification of a version range.
+  The value MUST adhere to the `Version Range Specification <VERSION-RANGE-SPEC.rst>`_.
+  This qualifier is mutually exclusive with the ``version`` component.
 
 - ``repository_url`` is an extra URL for an alternative, non-default package
   repository or registry. When a package does not come from the default public

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -423,6 +423,9 @@ all package types:
 - ``vers`` allows the specification of a version range.
   The value MUST adhere to the `Version Range Specification <VERSION-RANGE-SPEC.rst>`_.
   This qualifier is mutually exclusive with the ``version`` component.
+  For example::
+
+       pkg:pypi/django?vers=vers%3Apypi%2F%3E%3D1.11.0%7C%21%3D1.11.1%7C%3C2.0.0
 
 - ``repository_url`` is an extra URL for an alternative, non-default package
   repository or registry. When a package does not come from the default public

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -420,6 +420,10 @@ download URL, VCS URL or checksums in an API, database or web form.
 With this warning, the known ``key`` and ``value`` defined here are valid for use in
 all package types:
 
+- ``vers`` is a replacement for the component ``version``.
+  This allows to define a version range, instead of a single version.
+  The value of this qualifier MUST comply to `version range spec <VERSION-RANGE-SPEC.rst>`_.
+
 - ``repository_url`` is an extra URL for an alternative, non-default package
   repository or registry. When a package does not come from the default public
   package repository for its ``type`` a ``purl`` may be qualified with this extra


### PR DESCRIPTION
As sketched by @pombredanne and discusses in a PURL community meeting,
here is the qualifier `vers`.

example usage: `pkg:cpan/AUTHOR/Module-Name?vers=vers%3Acpan%2F%3E%3D2.2.0%7C%21%3D%202.2.1%7C%3C2.3.0` 

- closes #386