### PR TITLE
subpath: parsing stops after segments are clear

### DIFF
--- a/purl-specification.md
+++ b/purl-specification.md
@@ -492,8 +492,9 @@ To parse a `purl` string in its components:
   - Percent-decode each segment
   - Discard any ‘.’ or ‘..’ segment from that split
   - UTF-8-decode each segment if needed in your programming language
-  - Join segments back with a ‘/’
-  - This is the `subpath`
+  - This list of path segments is the ``subpath``
+  - You may escape these path segments if needed by your environment (operating system, file system, programming language, shell, etc)
+  - You may join these path segments with the path delimiter of your environment (operating system, file system, etc)
 
 - Split the `remainder` once from right on ‘?’
 


### PR DESCRIPTION
as proposed via https://github.com/package-url/purl-spec/issues/448#issuecomment-2781381449:

> the [subpath parsing] process joins on `/` to produce a final result.
>  - Joining path segments is not in the domain of PURL.
>   - I think the spec should stop after the path-segments are clear. Joining segments on FileSystem/OperatingSystem dependent path separators (`/`, `\`, `>`, etc - see <https://en.wikipedia.org/wiki/Path_(computing)> for more) is out of scope of the spec.
>   - The same with environment/FileSystem dependent character escapes.
  

----

is part of #448