### PR TITLE
Namespace/subpath: simplify parsing

### DIFF
--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -361,7 +361,7 @@ To parse a ``purl`` string in its components:
   - Split the right side on '/'
   - Percent-decode each segment
   - UTF-8-decode each segment if needed in your programming language
-  - Discard any segment that is empty, equal to `.` or `..`
+  - Discard any segment that is empty, or equal to `.` or `..`
   - Signal an error if any segment contains a solidus `/`
   - Join segments back with a '/'
   - This is the ``subpath``
@@ -413,7 +413,7 @@ To parse a ``purl`` string in its components:
 
   - Percent-decode each segment
   - UTF-8-decode each segment if needed in your programming language
-  - Discard any segment that is empty, equal to `.` or `..`
+  - Discard any segment that is empty, or equal to `.` or `..`
   - Signal an error if any segment contains a solidus `/`
   - Apply type-specific normalization to each segment if needed
   - Join segments back with a '/'

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -358,12 +358,11 @@ To parse a ``purl`` string in its components:
 - Split the ``purl`` string once from right on '#'
 
   - The left side is the ``remainder``
-  - Strip the right side from leading and trailing '/'
-  - Split this on '/'
-  - Discard any empty string segment from that split
+  - Split the right side on '/'
   - Percent-decode each segment
-  - Discard any '.' or '..' segment from that split
   - UTF-8-decode each segment if needed in your programming language
+  - Discard any segment that is empty, equal to `.` or `..`
+  - Signal an error if any segment contains a solidus `/`
   - Join segments back with a '/'
   - This is the ``subpath``
 
@@ -412,9 +411,10 @@ To parse a ``purl`` string in its components:
 
 - Split the ``remainder`` on '/'
 
-  - Discard any empty segment from that split
   - Percent-decode each segment
   - UTF-8-decode each segment if needed in your programming language
+  - Discard any segment that is empty, equal to `.` or `..`
+  - Signal an error if any segment contains a solidus `/`
   - Apply type-specific normalization to each segment if needed
   - Join segments back with a '/'
   - This is the ``namespace``


### PR DESCRIPTION
This PR:

- Uniformizes the treatment of `namespace` and `subpath`: all segments that are empty or equal to one of `.` or `..` should be discarded.
- Moves the check for `.` and `..` segments after UTF-8 decoding. This ensures that overlong encoding of `.` (like `%C0%AE`, `%E0%80%AE`, `%F0%80%80%AE`) are also discarded.
- Requires the parser to throw an error if an (percent-encoded) solidus `/` is encountered in any path segment.