### PR TITLE
Clarify namespace and name components

### DIFF
--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -143,7 +143,7 @@ The rules for each component are:
   - Unless required by the package's ``type`` definition in `<PURL-TYPES.rst>`_,
     the ``namespace`` is optional.
   - If present, the ``namespace`` MAY contain one or more segments, separated
-    by a single slash '/' character.
+    by a single unencoded slash '/' character.
   - All leading and trailing slashes '/' are not significant and SHOULD be
     stripped in the canonical form. They are not part of the ``namespace``.
   - Each ``namespace`` segment MUST be a percent-encoded string.

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -140,8 +140,10 @@ The rules for each component are:
 
 - **namespace**:
 
-  - The optional ``namespace`` contains zero or more segments, separated by a
-    single slash '/' character.
+  - Unless required by the package's ``type`` definition in `<PURL-TYPES.rst>`_,
+    the ``namespace`` is optional.
+  - If present, the ``namespace`` MAY contain one or more segments, separated
+    by a single slash '/' character.
   - All leading and trailing slashes '/' are not significant and SHOULD be
     stripped in the canonical form. They are not part of the ``namespace``.
   - Each ``namespace`` segment MUST be a percent-encoded string.
@@ -149,7 +151,8 @@ The rules for each component are:
 
     - MUST NOT contain any slash '/' characters
     - MUST NOT be empty
-    - MAY contain any ASCII character other than '/'
+    - MAY contain any ASCII character other than '/' unless the package's
+      ``type`` definition provides otherwise.
 
   - A URL host or Authority MUST NOT be used as a ``namespace``. Use instead a
     ``repository_url`` qualifier. Note however that for some types, the
@@ -163,26 +166,8 @@ The rules for each component are:
   - All leading and trailing slashes '/' are not significant and SHOULD be
     stripped in the canonical form. They are not part of the ``name``.
   - A ``name`` MUST be a percent-encoded string.
-  - When percent-decoded, a ``name`` MAY contain any ASCII character.
-
-----
-
-    - [QUESTION] What about parsing PURLs without names?  Is that relevant here or in a separate issue and PR?
-
-      Incorrect parsing for PURLs without names
-      https://github.com/package-url/packageurl-python/issues/131
-
-      - The example is pkg:swift/github.com/Alamofire/@5.4.3
-
-      - Matt says this should fail, Tom says no, to me it looks like the '/'between the name and the '@' version separator is simply stripped/normalized.
-
-      - Following the "How to parse..." steps, at the 6th top-level bullet, we have an error:
-
-        The remainder we start with is `remainder = github.com/Alamofire/`
-
-        The top bullet step is "Split the remainder once from right on '/'", and we expect a left side (the new remainder) and a right side (the name) but there is no right side -- it is empty
-
-----
+  - When percent-decoded, a ``name`` MAY contain any ASCII character unless
+    prohibited by the package's ``type`` definition in `<PURL-TYPES.rst>`_.
 
 
 - **version**:

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -152,7 +152,7 @@ The rules for each component are:
 
     - MUST NOT contain any slash '/' characters
     - MUST NOT be empty
-    - MAY contain any ASCII character other than '/' unless the package's
+    - MAY contain any Unicode character other than '/' unless the package's
       ``type`` definition provides otherwise.
 
   - A URL host or Authority MUST NOT be used as a ``namespace``. Use instead a

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -114,8 +114,9 @@ Rules for each ``purl`` component
 
 A ``purl`` string is an ASCII URL string composed of seven components.
 
-Except as expressly stated otherwise in this section, all components MUST be
-encoded as defined in the "Character encoding" section.
+Some components are allowed to use other characters beyond ASCII: these
+components must then be UTF-8-encoded strings and percent-encoded as defined in
+the "Character encoding" section.
 
 The rules for each component are:
 
@@ -150,7 +151,10 @@ The rules for each component are:
     - MUST NOT be empty
     - MAY contain any ASCII character other than '/'
 
-        - Is an unencoded colon ':' permitted?
+      - [QUESTION] Is an unencoded colon ':' permitted?
+
+      - feat: fix parsing of names and namespaces with colons
+        https://github.com/package-url/packageurl-python/pull/178
 
   - A URL host or Authority MUST NOT be used as a ``namespace``. Use instead a
     ``repository_url`` qualifier. Note however that for some types, the
@@ -165,30 +169,30 @@ The rules for each component are:
   - A ``name`` MUST be a percent-encoded string.
   - A ``name`` MAY contain any ASCII character.
 
-        - Is an unencoded colon ':' permitted?  See, e.g.,
+    - [QUESTION] Is an unencoded colon ':' permitted?  See, e.g.,
 
-            - feat: fix parsing of names and namespaces with colons
-              https://github.com/package-url/packageurl-python/pull/178
+      feat: fix parsing of names and namespaces with colons
+      https://github.com/package-url/packageurl-python/pull/178
 
-        - Is a percent-encoded slash '/' permitted?  See, e.g.,
+    - [QUESTION] Is a percent-encoded slash '/' permitted?  See, e.g.,
 
-            - fix: escape / in names and versions
-              https://github.com/package-url/packageurl-python/pull/123
+      fix: escape / in names and versions
+      https://github.com/package-url/packageurl-python/pull/123
 
-            - Incorrect parsing for PURLs without names
-              https://github.com/package-url/packageurl-python/issues/131
+      Incorrect parsing for PURLs without names
+      https://github.com/package-url/packageurl-python/issues/131
 
-                - The example is pkg:swift/github.com/Alamofire/@5.4.3
+      - The example is pkg:swift/github.com/Alamofire/@5.4.3
 
-                - Matt says this should fail, Tom says no, to me it looks like the '/'between the name and the '@' version separator is simply stripped/normalized.
+      - Matt says this should fail, Tom says no, to me it looks like the '/'between the name and the '@' version separator is simply stripped/normalized.
 
-                - Following the "How to parse..." steps, at the 6th top-level bullet, we have an error:
+      - Following the "How to parse..." steps, at the 6th top-level bullet, we have an error:
 
-                    The remainder we start with is
+        The remainder we start with is `remainder = github.com/Alamofire/`
 
-                        remainder = github.com/Alamofire/
+        The top bullet step is "Split the remainder once from right on '/'", and we expect a left side (the new remainder) and a right side (the name) but there is no right side -- it is empty
 
-                    The top bullet step is "Split the remainder once from right on '/'", and we expect a left side (the new remainder) and a right side (the name) but there is no right side -- it is empty
+    - [QUESTION] '+' in name???  See https://github.com/package-url/packageurl-java/pull/161/files#diff-7b5521d0eae4902cc692bf74406e30e197f70f8e1978a59d35346675d1ef5a07R316-R317
 
 
 - **version**:
@@ -262,14 +266,6 @@ A canonical ``purl`` is an ASCII string composed of these characters:
 - these punctuation marks ``%.-_~`` (percent sign '%', period '.', dash '-',
   underscore '_' and tilde '~').
 
-The alphanumeric characters do not need to be percent-encoded.
-
-The ``purl`` separators MUST be encoded as provided in the "``purl`` separators" subsection below.
-
-The punctuation marks ``.-_~`` (period '.', dash '-', underscore '_' and tilde '~') do not need to be percent-encoded.
-
-The percent sign '%' MUST NOT be percent-encoded when used to represent a percent-encoded character but MUST be percent-encoded when used for any other purpose.
-
 All other characters MUST be encoded as UTF-8 and then percent-encoded.
 In addition, each component specifies its permitted characters and
 its percent-encoding rules.
@@ -302,16 +298,8 @@ When applying percent-encoding or decoding to a string, use the rules of RFC
 Each component defines when and how to apply percent-encoding and decoding to
 its content.
 
-Unless otherwise provided in the "Rules for each ``purl`` component" section
-above, when percent-encoding is required, all characters MUST be encoded except
-for the following:
-
-- a ``purl`` separator when being used as a ``purl`` separator
-- the colon ':', whether used as a ``purl`` separator or otherwise
-- ['+' in name???  '+' in version???  See https://github.com/package-url/packageurl-java/pull/161/files#diff-7b5521d0eae4902cc692bf74406e30e197f70f8e1978a59d35346675d1ef5a07R316-R317]
-
-In addition, where the space ' ' is permitted, it MUST be percent-encoded as
-'%20'.
+When percent-encoding is required, all characters MUST be encoded except
+for the colon ':'.
 
 
 How to build ``purl`` string from its components

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -142,8 +142,7 @@ The rules for each component are:
 
 - **namespace**:
 
-  - Unless required by the package's ``type`` definition in `<PURL-TYPES.rst>`_,
-    the ``namespace`` is optional.
+  - The ``namespace`` is optional, unless required by the package's ``type`` definition.
   - If present, the ``namespace`` MAY contain one or more segments, separated
     by a single unencoded slash '/' character.
   - All leading and trailing slashes '/' are not significant and SHOULD be

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -147,14 +147,9 @@ The rules for each component are:
   - Each ``namespace`` segment MUST be a percent-encoded string.
   - When percent-decoded, a segment:
 
-    - MUST NOT contain one or more slash '/' characters
+    - MUST NOT contain any slash '/' characters
     - MUST NOT be empty
     - MAY contain any ASCII character other than '/'
-
-      - [QUESTION] Is an unencoded colon ':' permitted?
-
-      - feat: fix parsing of names and namespaces with colons
-        https://github.com/package-url/packageurl-python/pull/178
 
   - A URL host or Authority MUST NOT be used as a ``namespace``. Use instead a
     ``repository_url`` qualifier. Note however that for some types, the
@@ -165,19 +160,14 @@ The rules for each component are:
 
   - The ``name`` is prefixed by a single slash '/' separator when the
     ``namespace`` is not empty.
-  - This '/' is not part of the ``name``.
+  - All leading and trailing slashes '/' are not significant and SHOULD be
+    stripped in the canonical form. They are not part of the ``name``.
   - A ``name`` MUST be a percent-encoded string.
-  - A ``name`` MAY contain any ASCII character.
+  - When percent-decoded, a ``name`` MAY contain any ASCII character.
 
-    - [QUESTION] Is an unencoded colon ':' permitted?  See, e.g.,
+----
 
-      feat: fix parsing of names and namespaces with colons
-      https://github.com/package-url/packageurl-python/pull/178
-
-    - [QUESTION] Is a percent-encoded slash '/' permitted?  See, e.g.,
-
-      fix: escape / in names and versions
-      https://github.com/package-url/packageurl-python/pull/123
+    - [QUESTION] What about parsing PURLs without names?  Is that relevant here or in a separate issue and PR?
 
       Incorrect parsing for PURLs without names
       https://github.com/package-url/packageurl-python/issues/131
@@ -192,7 +182,7 @@ The rules for each component are:
 
         The top bullet step is "Split the remainder once from right on '/'", and we expect a left side (the new remainder) and a right side (the name) but there is no right side -- it is empty
 
-    - [QUESTION] '+' in name???  See https://github.com/package-url/packageurl-java/pull/161/files#diff-7b5521d0eae4902cc692bf74406e30e197f70f8e1978a59d35346675d1ef5a07R316-R317
+----
 
 
 - **version**:

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -142,24 +142,24 @@ The rules for each component are:
 
   - The optional ``namespace`` contains zero or more segments, separated by slash
     '/'
-  - Leading and trailing slashes '/' are not significant and should be stripped
+  - Leading and trailing slashes '/' are not significant and SHOULD be stripped
     in the canonical form. They are not part of the ``namespace``
-  - Each ``namespace`` segment must be a percent-encoded string
+  - Each ``namespace`` segment MUST be a percent-encoded string
   - When percent-decoded, a segment:
 
-    - must not contain a '/'
-    - must not be empty
+    - MUST NOT contain a '/'
+    - MUST NOT be empty
 
-  - A URL host or Authority must NOT be used as a ``namespace``. Use instead a
+  - A URL host or Authority MUST NOT be used as a ``namespace``. Use instead a
     ``repository_url`` qualifier. Note however that for some types, the
     ``namespace`` may look like a host.
 
 
 - **name**:
 
-  - The ``name`` is prefixed by a '/' separator when the ``namespace`` is not empty
+  - The ``name`` is prefixed by a slash '/' separator when the ``namespace`` is not empty
   - This '/' is not part of the ``name``
-  - A ``name`` must be a percent-encoded string
+  - A ``name`` MUST be a percent-encoded string
 
 
 - **version**:

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -273,8 +273,8 @@ When applying percent-encoding or decoding to a string, use the rules of RFC
 Each component defines when and how to apply percent-encoding and decoding to
 its content.
 
-When percent-encoding is required, all characters MUST be encoded except
-for the colon ':'.
+When percent-encoding is required, all characters MUST be encoded except for
+the colon ':'.
 
 
 How to build ``purl`` string from its components
@@ -413,7 +413,7 @@ To parse a ``purl`` string in its components:
 - Split the ``remainder`` once from right on '/'
 
   - The left side is the ``remainder``
-  - Strip all leading [and trailing '/'] characters (e.g., '/', '//' and so on)
+  - Strip all leading characters (e.g., '/', '//' and so on)
     from the right side
   - Percent-decode the right side. This is the ``name``
   - UTF-8-decode this ``name`` if needed in your programming language
@@ -422,7 +422,7 @@ To parse a ``purl`` string in its components:
 
 - Split the ``remainder`` on '/'
 
-  - Strip all leading [and trailing] '/' characters (e.g., '/', '//' and so on)
+  - Strip all leading '/' characters (e.g., '/', '//' and so on)
     from that split
   - Discard any empty segment from that split
   - Percent-decode each segment

--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -167,7 +167,7 @@ The rules for each component are:
   - All leading and trailing slashes '/' are not significant and SHOULD be
     stripped in the canonical form. They are not part of the ``name``.
   - A ``name`` MUST be a percent-encoded string.
-  - When percent-decoded, a ``name`` MAY contain any ASCII character unless
+  - When percent-decoded, a ``name`` MAY contain any Unicode character unless
     prohibited by the package's ``type`` definition in `<PURL-TYPES.rst>`_.
 
 


### PR DESCRIPTION
- This initial commit begins to address https://github.com/package-url/purl-spec/issues/381, starting with a few [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119) updates.  (Turning next to a review of the other issues and PRs listed in issue 381.)