### PR TITLE
Subpath: simplify parsing

### DIFF
--- a/docs/how-to-parse.md
+++ b/docs/how-to-parse.md
@@ -11,12 +11,11 @@ To parse a `purl` string in its components:
 - Split the `purl` string once from right on '#'
 
   - The left side is the `remainder`
-  - Strip the right side from leading and trailing '/'
-  - Split this on '/'
-  - Discard any empty string segment from that split
+  - Split the right side on `/`
   - Percent-decode each segment
-  - Discard any '.' or '..' segment from that split
   - UTF-8-decode each segment if needed in your programming language
+  - Discard any segment that is empty, or equal to `.` or `..`
+  - Report an error if any segment contains a slash `/`
   - Join segments back with a '/'
   - This is the `subpath`
 


### PR DESCRIPTION
This PR contains the part of #452 that is specific to `subpath`:

- Moves the check for `.` and `..` segments after UTF-8 decoding. This ensures that overlong encoding of `.` (like `%C0%AE`, `%E0%80%AE`, `%F0%80%80%AE`) are also discarded.
- Requires the parser to throw an error if an (percent-encoded) solidus `/` is encountered in any path segment.

----

* Closes the parser part of #448
* part of #379