### PR TITLE
subpath: serializing uses segments

### DIFF
--- a/purl-specification.md
+++ b/purl-specification.md
@@ -465,8 +465,7 @@ To build a `purl` string from its components:
   ‘..’ segments:
 
   - Append ‘\#’ to the `purl`
-  - Strip the `subpath` from leading and trailing ‘/’
-  - Split this on ‘/’ as segments
+  - Divide the `subpath` into segments using the path delimiter of your environment (operating system, file system, etc)
   - Discard empty, ‘.’ and ‘..’ segments
   - Percent-encode each segment
   - UTF-8-encode each segment if needed in your programming language


### PR DESCRIPTION
path segments are environment-dependent, and therefore, the splitting is not really in our domain.
Anyway, we can improve our process in the correct direction, by using "path delimiter" instead of `'/'`.

----

- see also https://github.com/package-url/purl-spec/pull/449

-----

this is the serialization-part implied as proposed via https://github.com/package-url/purl-spec/issues/448#issuecomment-2781381449:

> the [subpath parsing] process joins on `/` to produce a final result.
> - [...]
> - I think the spec should stop after the path-segments are clear. Joining segments on FileSystem/OperatingSystem dependent path separators (`/`, `\`, `>`, etc - see <https://en.wikipedia.org/wiki/Path_(computing)> for more) is out of scope of the spec.
> - [...]


----

is part of #448