### PR TITLE
Update Elixir Implementation Reference

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,7 +157,7 @@ Known implementations
 ~~~~~~~~~~~~~~~~~~~~~
 
 - .NET: https://github.com/package-url/packageurl-dotnet
-- Elixir: https://github.com/maennchen/purl
+- Erlang / Elixir: https://github.com/erlef/purl
 - Go: https://github.com/package-url/packageurl-go
 - Java: https://github.com/package-url/packageurl-java,
   https://github.com/sonatype/package-url-java


### PR DESCRIPTION
The library was moved from @maennchen to @erlef.

The library was rewritten to support both Erlang & Elixir.