### PR TITLE
Add semver to generic schemes

### DIFF
--- a/VERSION-RANGE-SPEC.rst
+++ b/VERSION-RANGE-SPEC.rst
@@ -658,6 +658,8 @@ These are generic schemes, to use sparingly for special cases:
   non-negative integers, and ignoring leading zeros. Interpretation of the
   version should stop at the first character that is not a digit or a dot.
 
+- **semver**: a generic scheme that uses the same syntax as ``semver``. It follows the MAJOR.MINOR.PATCH format and is defined the Semantic Versioning Specification 2.0.0. 
+
 A separate document will provide details for each versioning scheme and:
 
 - how to convert its native range notation to the ``vers`` notation and back.


### PR DESCRIPTION
This PR adds semantic versioning 2.0.0 to the generic schemes. 
It is already implemented in [univers](https://github.com/aboutcode-org/univers/blob/9c15915e51f03d308e4ff5c1f43f634408b98895/src/univers/versions.py#L183).
Addresses https://github.com/package-url/purl-spec/issues/264