### PR TITLE
TYPES: Add `gitee` type

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -281,6 +281,20 @@ version control repository such as a bare git repo.
       pkg:generic/openssl@1.1.10g?download_url=https://openssl.org/source/openssl-1.1.0g.tar.gz&checksum=sha256:de4d501267da
       pkg:generic/bitwarderl?vcs_url=git%2Bhttps://git.fsfe.org/dxtr/bitwarderl%40cc55108da32
 
+gitee
+------
+``gitee`` for Gitee-based packages:
+
+- The default repository is ``https://gitee.com``.
+- The ``namespace`` is the user or organization. It is case sensitive.
+- The ``name`` is the repository name. It is case sensitive.
+- The ``version`` is a commit or tag.
+- Examples::
+
+      pkg:gitee/smallc/SpringBlade@v4.5.0
+      pkg:gitee/mindspore/mindformers@v1.6.0-beta1
+      pkg:gitee/mindspore/mindformers@58410b6
+
 github
 ------
 ``github`` for GitHub-based packages:

--- a/test-suite-data.json
+++ b/test-suite-data.json
@@ -180,6 +180,18 @@
     "is_invalid": false
   },
   {
+    "description": "gitee names are case sensitive",
+    "purl": "pkg:gitee/smallc/SpringBlade@v4.5.0",
+    "canonical_purl": "pkg:gitee/smallc/SpringBlade@v4.5.0",
+    "type": "gitee",
+    "namespace": "smallc",
+    "name": "SpringBlade",
+    "version": "v4.5.0",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
     "description": "nuget names are case sensitive",
     "purl": "pkg:Nuget/EnterpriseLibrary.Common@6.0.1304",
     "canonical_purl": "pkg:nuget/EnterpriseLibrary.Common@6.0.1304",


### PR DESCRIPTION
# Motivation

[Gitee](https://gitee.com/) is the biggest code hosting platform in Asia with many original projects. We hope Gitee can be accepted as a type so these projects can be tracked with PURL.

# Changes

- Add a first draft for the description of the gitee type
- Add one simple test case to the suite