### PR TITLE
Add new PURL type: 'powershell'

### DIFF
--- a/purl-types-index.json
+++ b/purl-types-index.json
@@ -25,6 +25,7 @@
   "npm",
   "nuget",
   "oci",
+  "psgallery",
   "pub",
   "pypi",
   "qpkg",

--- a/tests/types/powershell-test.json
+++ b/tests/types/powershell-test.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://packageurl.org/schemas/purl-test.schema-1.0.json",
+  "tests": [
+    {
+      "description": "Powershell names are case insensitive. Roundtrip test for Powershell with version.",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:Psgallery/EnterpriseLibrary.Common@6.0.1304",
+      "expected_output": "pkg:psgallery/enterpriselibrary.common@6.0.1304",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Powershell names are case insensitive. Parse test with version.",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:psgallery/Enterpriselibrary.Common@6.0.1304",
+      "expected_output": {
+        "type": "psgallery",
+        "namespace": null,
+        "name": "enterpriselibrary.common",
+        "version": "6.0.1304",
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Powershell names are case insensitive. Build test with version.",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "psgallery",
+        "namespace": null,
+        "name": "EnterpriseLibrary.Common",
+        "version": "6.0.1304",
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_output": "pkg:psgallery/enterpriselibrary.common@6.0.1304",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Powershell names are case insensitive. Roundtrip test for Powershell without version.",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:Psgallery/EnterpriseLibrary.Common",
+      "expected_output": "pkg:psgallery/enterpriselibrary.common",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Powershell names are case insensitive. Parse test without version.",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:psgallery/Enterpriselibrary.Common",
+      "expected_output": {
+        "type": "psgallery",
+        "namespace": null,
+        "name": "enterpriselibrary.common",
+        "version": null,
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Powershell names are case insensitive. Build test without version.",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "psgallery",
+        "namespace": null,
+        "name": "EnterpriseLibrary.Common",
+        "version": null,
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_output": "pkg:psgallery/enterpriselibrary.common",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    }
+  ]
+}

--- a/types-doc/psgallery-definition.md
+++ b/types-doc/psgallery-definition.md
@@ -1,0 +1,46 @@
+<!--  NOTE: Auto-generated from the JSON PURL type definition.
+Do not manually edit this file. Edit the JSON type definition instead. -->
+
+# PURL Type Definition: psgallery
+
+- **Type Name:** PowerShell Gallery
+- **Description:** PowerShell Gallery packages
+- **Schema ID:** `https://packageurl.org/types/powershell-definition.json`
+
+## PURL Syntax
+
+The structure of a PURL for this package type is:
+
+    pkg:psgallery/<name>@<version>?<qualifiers>#<subpath>
+
+## Repository Information
+
+- **Use Repository:** Yes
+- **Default Repository URL:** https://www.powershellgallery.com
+
+## Namespace definition
+
+- **Requirement:** Prohibited
+- **Note:** `there is no namespace`
+
+## Name definition
+
+- **Requirement:** Required
+- **Native Label:** version
+- **Note:** `The `name` is not case sensitive and must be lowercased.`
+
+## Version definition
+
+- **Requirement:** Optional
+- **Native Label:** version
+- **Note:** `The `version` is not case sensitive and must be lowercased.`
+
+## Examples
+
+- `pkg:psgallery/pswindowsupdate@2.2.1.5`
+- `pkg:psgallery/powershellget@3.0.22-beta22`
+- `pkg:psgallery/aws.tools.cloudwatch@4.1.820`
+
+## Note
+
+There is no namespace per se even if the common convention is to use dot-separated package names where the first segment is namespace-like.

--- a/types/powershell-definition.json
+++ b/types/powershell-definition.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
+  "$id": "https://packageurl.org/types/powershell-definition.json",
+  "type": "psgallery",
+  "type_name": "PowerShell Gallery",
+  "description": "PowerShell Gallery packages",
+  "repository": {
+    "use_repository": true,
+    "default_repository_url": "https://www.powershellgallery.com"
+  },
+  "namespace_definition": {
+    "requirement": "prohibited",
+    "note": "there is no namespace"
+  },
+  "name_definition": {
+    "requirement": "required",
+    "native_name": "version",
+    "case_sensitive": false,
+    "note": "The `name` is not case sensitive and must be lowercased."
+  },
+  "version_definition": {
+    "requirement": "optional",
+    "native_name": "version",
+    "case_sensitive": false,
+    "note": "The `version` is not case sensitive and must be lowercased."
+  },
+  "note": "There is no namespace per se even if the common convention is to use dot-separated package names where the first segment is namespace-like.",
+  "examples": [
+      "pkg:psgallery/pswindowsupdate@2.2.1.5",
+      "pkg:psgallery/powershellget@3.0.22-beta22",
+      "pkg:psgallery/aws.tools.cloudwatch@4.1.820"
+  ]
+}


### PR DESCRIPTION
### Motivation
Add support for PowerShell modules distributed via the [PowerShell Gallery](https://www.powershellgallery.com/).
PowerShell is a widely used automation and configuration framework developed by Microsoft. Its module ecosystem is centralized in the PowerShell Gallery, which currently hosts over 450,000 packages, making it a significant and active package registry in the software ecosystem.