### PR TITLE
Clarify version definition #380

### DIFF
--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -166,14 +166,12 @@ The rules for each component are:
 
 - **version**:
 
-  - The ``version`` is prefixed by a '@' separator when not empty
-  - This '@' is not part of the ``version``
-  - A ``version`` must be a percent-encoded string
-
-  - A ``version`` is a plain and opaque string. Some package ``types`` use versioning
-    conventions such as SemVer for NPMs or NEVRA conventions for RPMS. A ``type``
-    may define a procedure to compare and sort versions, but there is no
-    reliable and uniform way to do such comparison consistently.
+  - The ``version`` is prefixed by a '@' separator when not empty.
+  - This '@' is not part of the ``version``.
+  - A ``version`` MUST be a percent-encoded string.
+  - When percent-decoded, a ``version`` MAY contain any Unicode character unless
+    the package's ``type`` definition provides otherwise.
+  - A ``version`` is a plain and opaque string.
 
 
 - **qualifiers**:

--- a/faq.rst
+++ b/faq.rst
@@ -46,3 +46,15 @@ package ``type``
 
 As a result, a purl spec implementation must return an error when encountering
 a ``type`` that contains a prohibited character.
+
+
+Version
+~~~~~~~
+
+**QUESTION**: How do package ``types`` handle the comparison and sorting of
+versions?
+
+**ANSWER**: Some package ``types`` use versioning conventions such as SemVer
+for NPMs or NEVRA conventions for RPMS. A ``type`` may define a procedure to
+compare and sort versions, but there is no reliable and uniform way to do such
+comparison consistently.


### PR DESCRIPTION
This PR updates the `version` definition and adds an entry to the FAQs document.

Reference: https://github.com/package-url/purl-spec/issues/380