### PR TITLE
Clarify subpath definition re permitted characters #379

### DIFF
--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -222,6 +222,8 @@ The rules for each component are:
     - MUST NOT contain a '/'
     - MUST NOT be any of '..' or '.'
     - MUST NOT be empty
+    - MAY contain any Unicode character unless this ``subpath`` definition or
+      the package's ``type`` definition provides otherwise.
 
   - The ``subpath`` MUST be interpreted as relative to the root of the package
 


### PR DESCRIPTION
Clarify which characters are permitted in the `subpath` component.

Reference: https://github.com/package-url/purl-spec/issues/379