### PR TITLE
Add new PURL type: 'terraform'

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -113,7 +113,6 @@ Other candidate types to define
 - ``puppet`` for Puppet Forge packages:
 - ``sourceforge`` for Sourceforge-based packages:
 - ``sublime`` for Sublime packages:
-- ``terraform`` for Terraform modules
 - ``vagrant`` for Vagrant boxes
 - ``vim`` for Vim scripts packages:
 - ``wordpress`` for Wordpress packages:

--- a/purl-types-index.json
+++ b/purl-types-index.json
@@ -30,5 +30,6 @@
   "qpkg",
   "rpm",
   "swid",
-  "swift"
+  "swift",
+  "terraform"
 ]

--- a/types-doc/terraform-definition.md
+++ b/types-doc/terraform-definition.md
@@ -1,0 +1,42 @@
+<!--  NOTE: Auto-generated from the JSON PURL type definition.
+Do not manually edit this file. Edit the JSON type definition instead. -->
+
+# PURL Type Definition: terraform
+
+- **Type Name:** Terraform providers and modules
+- **Description:** Terraform providers and modules
+- **Schema ID:** `https://packageurl.org/types/terraform-definition.json`
+
+## PURL Syntax
+
+The structure of a PURL for this package type is:
+
+    pkg:terraform/<namespace>/<name>@<version>?<qualifiers>#<subpath>
+
+## Repository Information
+
+- **Use Repository:** Yes
+- **Default Repository URL:** https://registry.terraform.io
+- **Note:** The HashiCorp registry is the default. Use the standard repository_url qualifier to point to another registry.
+
+## Namespace definition
+
+- **Requirement:** Required
+- **Case Sensitive:** Yes
+- **Note:** `The namespace is the provider or module namespace, which is usually the organization or vendor name.`
+
+## Name definition
+
+- **Case Sensitive:** Yes
+- **Native Label:** Name is the name of the terraform provider or module.
+
+## Version definition
+
+- **Case Sensitive:** Yes
+- **Native Label:** Version is the package version and is required.
+
+## Examples
+
+- `pkg:terraform/hashicorp/aws@6.0.0`
+- `pkg:terraform/terraform-aws-modules/vpc@6.0.1`
+- `pkg:terraform/terraform-aws-modules/vpc@6.0.1?registry_url=https://registry.example.com`

--- a/types/terraform-definition.json
+++ b/types/terraform-definition.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
+  "$id": "https://packageurl.org/types/terraform-definition.json",
+  "type": "terraform",
+  "type_name": "Terraform providers and modules",
+  "description": "Terraform providers and modules",
+  "repository": {
+    "use_repository": true,
+    "default_repository_url": "https://registry.terraform.io",
+    "note": "The HashiCorp registry is the default. Use the standard repository_url qualifier to point to another registry."
+  },
+  "namespace_definition": {
+    "requirement": "required",
+    "note": "The namespace is the provider or module namespace, which is usually the organization or vendor name.",
+    "case_sensitive": true
+  },
+  "name_definition": {
+    "case_sensitive": true,
+    "native_name": "Name is the name of the terraform provider or module."
+  },
+  "version_definition": {
+    "case_sensitive": true,
+    "native_name": "Version is the package version and is required."
+  },
+  "examples": [
+    "pkg:terraform/hashicorp/aws@6.0.0",
+    "pkg:terraform/terraform-aws-modules/vpc@6.0.1",
+    "pkg:terraform/terraform-aws-modules/vpc@6.0.1?registry_url=https://registry.example.com"
+  ]
+}


### PR DESCRIPTION
See #369 for details.

Please let me know what you think. This proposal is for now solely based on my ideas and I'm open for feedback. It might even make sense to define two distinct types `terraform-provider` and `terraform-module` for more clarity.