### PR TITLE
Remove plus from allowed character in type

### DIFF
--- a/PURL-SPECIFICATION.rst
+++ b/PURL-SPECIFICATION.rst
@@ -134,7 +134,7 @@ The rules for each component are:
 - **type**:
 
   - The package ``type`` MUST be composed only of ASCII letters and numbers,
-    period '.', plus '+', and dash '-'.
+    period '.', and dash '-'.
   - The ``type`` MUST start with an ASCII letter.
   - The ``type`` MUST NOT be percent-encoded.
   - The ``type`` is case insensitive. The canonical form is lowercase.
@@ -236,7 +236,6 @@ A canonical ``purl`` is composed of these permitted ASCII characters:
 - the Alphanumeric Characters: ``A to Z``, ``a to z``, ``0 to 9``,
 - the Punctuation Characters: ``.-_~`` (period '.',
   dash '-', underscore '_' and tilde '~'),
-- the Plus Character: ``+`` (plus '+'),
 - the Percent Character: ``%`` (percent sign '%'), and
 - the Separator Characters ``:/@?=&#`` (colon ':', slash '/', at sign '@',
   question mark '?', equal sign '=', ampersand '&' and pound sign '#').


### PR DESCRIPTION
The plus was not used in any type and was always to be encoded elsewhere.
No more plusses!

Reference: https://github.com/package-url/purl-spec/issues/436