### PR TITLE
Add minutes for 2025-07-09 and 2025-07-23 PURL community meetings #384

### DIFF
--- a/meetings/2025-07-09.md
+++ b/meetings/2025-07-09.md
@@ -1,0 +1,63 @@
+# Agenda for the PURL community meeting on 2025-07-09
+
+- **Host**: Remote
+- **Dates and times**:
+    - 16:00 to 17:00 UTC
+    - 18:00 to 19:00 CEST (Europe/Brussels)
+    - 12:00 to 13:00 EDT (America/New_York)
+    - 09:00 to 10:00 PDT (America/Los Angeles)
+    - 01:00 to 02:00 JST (Tokyo, Japan)
+
+- **Attendee information**:
+    - https://meet.google.com/ryq-aimn-ghd
+
+## Agenda items
+- Opening of the meeting and welcome
+- Meetings will follow the Ecma TC54 Code of Conduct https://github.com/Ecma-TC54/tg2/blob/main/CODE_OF_CONDUCT.md
+- GitHub project board – https://github.com/orgs/package-url/projects/1/views/1
+- Open issues/PRs –  https://docs.google.com/spreadsheets/d/1RKw0XB-xAPsZ09Uzj1W4ycYIvS1BVOyD/
+
+## Attendees
+- Philippe Ombredanne, creator of PURL, Lead maintainer of AboutCode, TC54-TG2 convener
+- Jon Moroney
+- Immanuel Kunz
+- Tom Alrich
+- Matt Rutkowski, IBM
+- Michael Herzog, AboutCode
+- John Horan, AboutCode
+
+## Notes
+- Meeting minutes are being kept and will be published, and the meeting will be recorded with Google Meet video and Gemini "note-taking".
+- Our code of conduct (link in agenda above) applies to this meeting.
+- Introductions.
+- Additional agenda items:
+    - Michael: PURL types update; a number of organizational topics to discuss if time permits, e.g., repo structuring, should VERS be separated from PURL (e.g., separate meetings, since they'll be on different schedules)
+    - John: nothing atm
+    - Jon: Can he help with any asynchronous work?
+    - Immanuel: 3 open PRs (1 already has an approval)
+    - Tom: CVE.org
+    - Philippe: PURL type schemas, Thomas Schmidt discussion re JSON Schema etc.
+    - Matt: there are 2 developers working on the website, internships end in 2 weeks but would like to keep working on this; they'll join call on 23rd to present their work (John H. will add to agenda for July 23rd meeting)
+- Summary
+    - Michael Herzog discussed plans for reorganizing the purl-spec repo post-v0.90 release, including the potential separation of VERS into its own repo, which Jon Moroney supported for technical reasons, while Philippe Ombredanne preferred a single repository but acknowledged the benefits.
+    - Philippe provided an update on the PURL type JSON Schema, including his draft PR, and discussed JSON Schema versions as well.  Philippe plans to stay on JSON Schema draft 7 for now, despite recommendations to switch to the 2020 version, while Matt Rutkowski raised concerns about tooling support.
+    - Matt emphasized the importance of normalization rules for PURL types to automate testing, but this does not seem to be practical for v1.0 with the Sept 1 deadline to submit the proposed PURL Standard to Ecma.
+    - Philippe outlined the PURL type definition structure and proposed a new schema for PURL tests, while Immanuel Kunz noted his three open PRs. Tom Alrich reported that the CVE Quality Working Group is incorporating PURL into their schema, and Tom, Jon and others discussed CPE and proprietary software identifiers.
+    - Michael proposed reorganizing the purl-spec repository and addressed the need to clarify the licensing for the PURL specification, and Philippe emphasized the need for community approval for any license change.
+- **Meeting Agenda and Volunteers** Michael Herzog introduced organizational topics for the repo after the v0.90 release, including potentially separating and scheduling different meetings for VERS due to their distinct standards and timelines (00:00:00). Jon Moroney volunteered for asynchronous work to help move things along (00:01:07). Matt Rutkowski announced that their two interns working on the website plan to present their progress at the next meeting on the 23rd (00:04:46).
+- **PURL Type Schemas Update** Philippe Ombredanne provided an update on PURL types, sharing a draft PR with three schemas. One schema is for a list of PURL types, serving as an index that could be generated when new types are added (00:05:42).
+- **JSON Schema Version Discussion** Philippe Ombredanne noted that the current draft uses an older JSON schema (draft 7) but, based on discussions with Thomas Schmidt, recommends switching to the 2020 version (six years old) for its expressiveness and widespread tool support (00:08:34). Matt Rutkowski expressed concerns about tooling support for versions beyond draft 7 in the open-source community, particularly for Go and JavaScript-based tools used for the website generator (00:11:45). Jon Moroney suggested identifying which languages and tooling ecosystems are critical to forge a path forward, agreeing that moving to a newer schema is a reasonable goal (00:13:01). Philippe Ombredanne stated their intent to stay on draft 7 for now, but noted that switching to a newer version would simplify things (00:14:59).
+- **Normalization Rules for PURL Types** Matt Rutkowski emphasized the importance of built-in normalization capabilities to enable consistent comparison of objects in a Bill of Materials at different points in time and suggested adding an identifier or a defined key for unambiguous normalization [this point applies more to an SBOM object than a PURL definition]  (00:17:45). Philippe Ombredanne acknowledged the need to rework the normalization section in the schema, as some rules are difficult to formalize, citing the "PyPI" example where underscores replace dashes (00:19:51). Jon Moroney agreed with Matt Rutkowski on defining clear normalization rules, suggesting that such rules would be PURL type-dependent and could be defined on a per-type basis in the spec (00:26:02).
+- **Over-Specification and Timelines** Michael Herzog raised a concern about over-specifying in the current phase of the PURL project, emphasizing that it will be much harder to undo things once something is proposed for the standard (00:25:17). Philippe Ombredanne agreed on the need to avoid going into deep rabbit holes with overly formal definitions that might be regretted later, especially given the September 1st timeline (00:32:05).
+- **PURL Type Definition Structure** Philippe Ombredanne outlined the structure of the PURL type definition, which includes fields for a specific package type (e.g., npm), a name, a description, and a list of reference URLs (00:30:49). The definition also specifies requirements for components like namespace, name, and version, allowing for formal definitions with regular expressions while trying to avoid over-complication (00:32:05).
+- **PURL Examples and Test Suite Schema** Philippe Ombredanne showed that PURL examples are currently defined as an array of strings. Matt Rutkowski questioned if they could be self-validating against the PURL type itself, suggesting an "array of PURL types" (00:35:25). Philippe Ombredanne acknowledged that a self-validating PURL type schema is a goal but unlikely to be achieved by the September 1st deadline. Philippe Ombredanne introduced a new schema for PURL tests, drawing inspiration from CSAF, which defines parsing tests with input (a string) and expected output (components), allowing for formal validation of canonical PURLs (00:36:31).
+- **Test Suite Targets** Philippe Ombredanne proposed the notion of "targets" for tests, separating essential tests for core specification conformance from tests for "funky" or recovery-parsing PURLs. This separation would help implementers distinguish between conforming to the base spec and supporting recovery capabilities, avoiding current ambiguities (00:40:25). Matt Rutkowski observed that PURL seems to be a right-sized specification for exploring this testing ecosystem, which Cyclone could benefit from (00:42:01).
+- **Immanuel's Pull Requests** Immanuel Kunz mentioned having three open PRs in PURL, with one already approved and the other two having ongoing conversations (00:01:07). Philippe Ombredanne confirmed that the non-controversial PRs could be merged, while the others just need a bit more review (00:44:58).
+- **CVE Quality Working Group and Software Identifiers** Tom Alrich reported that the CVE Quality Working Group (QWG) is moving quickly to incorporate PURL into their schema, with a preliminary meeting with the board scheduled (00:46:03). Jon Moroney elaborated that this is part of a larger RFD (Request for Discussions) process, a new decision-making framework (00:47:23). Two identifiers, Omnibor and PURL, are being proposed, with the idea of vendoring a tagged version of PURL once 0.90 is in place (00:48:45).
+- **CPE and Proprietary Software** Tom Alrich mentioned that NIST has indicated they will not continue to fix CPE (Common Platform Enumeration), which has been trying to be too many things. Jon Moroney suggested that CPE's future might primarily be for proprietary software, where vendors can register namespaces, as PURL and Omnibor do not handle proprietary software well due to the lack of visibility for naming (00:51:04). Tom Alrich referenced a proposal from the SBOM Forum for a SWID-based software tag created by suppliers for proprietary software, which would serve as the source of truth for PURL (00:52:12). Jon Moroney argued that without a managed registry for such identifiers, they become arbitrary strings that are difficult to validate and lead to namespace conflicts (00:53:19) (00:57:41).
+- **Registry for Proprietary Software Identifiers** Michael Herzog highlighted that the concept of supplier registries and master lists for physical goods (like in hardware manufacturing) provides a concreteness that is lacking in software, making it difficult to achieve the same level of certainty (00:55:26). Jon Moroney emphasized that without a registered component and a way to look it up, security researchers inspecting proprietary software might invent names, leading to namespace conflicts that are impossible to unwind (00:56:51).
+- **Product Unique Identification and European Cyber Resilience Act** Philippe Ombredanne introduced the European Cyber Resilience Act, noting that it mandates unique identification for products placed on the market. This regulation will require commercial vendors to provide a unique name for their products, necessitating a public registry or a discoverable system for these unique identifiers (00:59:15). Jon Moroney acknowledged the potential for multiple vendor-specific solutions but agreed that as long as definitions are clear, the system should function effectively (01:00:34).
+- **Repository Structure Reorganization** Michael Herzog proposed a significant reorganization of the PURL spec repository to prepare for version 0.90, including switching to markdown and creating separate files for different sections of the standard (01:01:37). This new structure aims to improve manageability and align with how other standards, like ECMA, SPDX, and Cyclone DX, organize their documentation (01:02:56) (01:04:50). Jon Moroney supported this initiative and suggested creating individual files for each PURL type within a dedicated directory (01:05:43).
+- **License Discussion** Michael Herzog highlighted the need to address the licensing for the PURL specification, noting confusion regarding the use of BSD3 clause in the ECMA part and MIT for other components (01:07:17). He suggested that MIT might be problematic for specifications due to its lack of patent language, favoring Apache or Community Specification License for better patent protection. Philippe Ombredanne emphasized the importance of community approval for any license change and reiterated the need for a license that offers robust patent protection, despite the low perceived risk of patent assertion (01:08:10).
+- **Separation of VERS Repository** Michael Herzog raised the idea of splitting the 'vers' component into a separate repository, a proposal supported by Jon Moroney for technical reasons, allowing independent iteration and better product management (01:10:02) (01:11:51). Philippe Ombredanne, while preferring a single repository, acknowledged the technical benefits of separation, including facilitating independent development and testing of PURL and Vers specifications (01:10:59) (01:16:26). The team agreed to continue discussion and aim for a decision by the next TG2 meeting, with a focus on increasing Vers implementations and formalizing tests (01:11:51).
+- The meeting was adjourned.

--- a/meetings/2025-07-23.md
+++ b/meetings/2025-07-23.md
@@ -1,0 +1,67 @@
+# Agenda for the PURL community meeting on 2025-07-23
+
+- **Host**: Remote
+- **Dates and times**:
+    - 16:00 to 17:00 UTC
+    - 18:00 to 19:00 CEST (Europe/Brussels)
+    - 12:00 to 13:00 EDT (America/New_York)
+    - 09:00 to 10:00 PDT (America/Los Angeles)
+    - 01:00 to 02:00 JST (Tokyo, Japan)
+
+- **Attendee information**:
+    - https://meet.google.com/ryq-aimn-ghd
+
+## Agenda items
+- Opening of the meeting and welcome
+- Meetings will follow the Ecma TC54 Code of Conduct https://github.com/Ecma-TC54/tg2/blob/main/CODE_OF_CONDUCT.md
+- GitHub project board – https://github.com/orgs/package-url/projects/1/views/1
+- Website presentation by Matt Rutkowski and colleagues
+- Jaime: Request for new univers release to unblock https://github.com/package-url/packageurl-python/pull/186
+- Jaime: How (late am I) to propose modifications to the conda type?
+    - Related discussion in the conda community: https://github.com/conda/ceps/pull/63#discussion_r2200716517
+
+## Attendees
+- Philippe Ombredanne, creator of PURL, Lead maintainer of AboutCode, TC54-TG2 convener
+- Jon Moroney
+- Immanuel Kunz
+- Tom Alrich
+- Matt Rutkowski, IBM
+- Michael Herzog, AboutCode
+- John Horan, AboutCode
+- Jaime Rodríguez-Guerra, Quansight
+- Abul Hasan Sheik Madhar Ali, IBM Intern
+- Steve Springett, ServiceNow / OWASP Foundation
+- Ralf Duli, IBM Intern
+- Nisha Kumar, Oracle
+- Joshua Kugler
+
+## Notes
+- Meeting minutes are being kept and will be published, and the meeting will be recorded with Google Meet video and Gemini "note-taking".
+- Our code of conduct (link in agenda above) applies to this meeting.
+- Introductions.
+- Additional agenda items:
+    - Jaime: Request for new univers release to unblock https://github.com/package-url/packageurl-python/pull/186
+- Summary
+    - Matt Rutkowski announced a website presentation by interns Abul Hasan Sheik Madhar Ali and Ralf Duli, showcasing backend functionality and future styling.
+    - Philippe Ombredanne provided an update on a major pull request for the PURL type JSON Schema, which will transition to a structured, generated single file for each package type and will simplify documentation.
+    - Michael Herzog emphasized the urgency of merging the JSON Schema PR to facilitate progress towards the PURL Spec 0.90 release.
+    - Jaime Rodríguez-Guerra requested a release for the univers project to unblock work on PEP 725, which Philippe Ombredanne agreed to handle.
+    - The team discussed the JSON Schema version, with Michael Herzog proposing Draft 7 for immediate use.
+- **Website Presentation** Matt Rutkowski announced a website presentation by the interns, Abul Hasan Sheik Madhar Ali and Ralph, who are working on the project (00:00:00). They presented the current backend functionality, which includes converting files to markdown and generating a sidebar for PURL specs (00:04:58).
+- **Website Styling and Future Plans** Abul Hasan Sheik Madhar Ali mentioned that the front end styling will match CycloneDX styles and colors, with the project built primarily on Docusaurus (00:05:52). Matt Rutkowski elaborated on the front page plan, which includes a rotating GIF showing different implementations. Michael Herzog noted that a pending major PR will convert everything to MD as native, which should simplify future work (00:07:06).
+- **Community Engagement and PRs** Michael Herzog mentioned the importance of having real people working on the project and Philippe Ombredanne acknowledged the great work by the interns and Matt Rutkowski (00:08:03). Michael Herzog noted that a color scheme or logo for PURL is not yet finalized, but the CycloneDX one is a good starting point (00:09:25). The team plans to target the next two-week community meeting to review the website again (00:12:40).
+- **OpenSSF Persona website** Jaime Rodríguez-Guerra shared that the OpenSSF Persona website also uses Docusaurus after migrating from Sphinx, emphasizing attention to accessibility details like contrast issues and navigation (00:09:25). They offered assistance and a blog post checklist for those interested in similar work (00:10:38).
+- **JSON Schema Pull Request** Philippe Ombredanne provided an update on the major pull request for the type JSON Schema, which involves building a JSON Schema to validate package types and extract test files (00:13:43). This will transition from a blob of text to a structured, generated single file for each package type (00:15:04).  Philippe Ombredanne highlighted that the new JSON Schema will simplify the process and generate clear, unambiguous definitions, reducing "poetic license" in PURL type definitions. The schema also generates documentation, which can be adapted or used to generate different outputs (00:16:54).
+- **Impact on Existing PRs and Migration Plan** Philippe Ombredanne acknowledged that the new schema will affect existing pull requests on package types, requiring some additional work for conversion (00:18:27). Michael Herzog clarified that they will prioritize merging the PR and then assist contributors with updating their existing PRs rather than asking them to redo the work (00:20:01).
+- **Test Suite Enhancements** Philippe Ombredanne explained that the new structure includes companion test files for each JSON file, designed to be explicit and reduce ambiguity, with tests ported from previous JSON files (00:22:38). They introduced the concept of "test groups" to differentiate between base conformance and advanced parser features (00:24:07).
+- **Definition of Base vs. Advanced Tests** Steve Springett inquired about the refinement of "base" versus "advanced" test definitions, and Philippe Ombredanne clarified that a test is considered "advanced" if the input is not strictly decoded components or a canonical PURL (00:25:44) (00:28:12). They noted that tests can also be marked as "expected to fail" with a reason provided (00:27:01).
+- **Urgency of Merging the PR** Michael Herzog emphasized the urgency of merging the large JSON Schema PR to facilitate feedback and progress towards the new structure and the PURL Spec 0.90 release (00:29:51) (00:35:05). They plan to restructure the repository and move the VERS Spec to a separate repository (00:36:40).
+- **Reviewing the PR and JSON Schema** Jon Moroney offered to review the JSON Schema PR by Friday, focusing on substantive comments (00:30:37). Philippe Ombredanne encouraged this, explaining the structure of the JSON Schema and the tests (00:31:42).
+- **Test Suite Execution** Jon Moroney asked about running the test suite, to which Philippe Ombredanne responded that existing implementations use the old test suite, and the new schema will require updates to the code but should simplify adoption (00:32:50). Michael Herzog stressed that the priority is getting the schema right for the Ecma standard (00:35:05).
+- **Versioned PURL Spec and Community Engagement** Michael Herzog reiterated the plan to release PURL Spec version 0.90 after Philippe Ombredanne's PR and other restructuring tasks are complete (00:20:01) (00:36:40). They also discussed re-engaging with various package communities to encourage ownership of PURL type data (00:41:49).
+- **univers Release Request** Jaime Rodríguez-Guerra requested a release for univers PR 159 (https://github.com/aboutcode-org/univers/pull/159) as the py.type marker file had been merged but not yet released (00:40:03). Philippe Ombredanne confirmed they would take care of the release immediately (00:40:59).
+- **cve-schema Updates and JSON Schema Version** Jon Moroney stated there were no major updates on the cve-schema (https://github.com/CVEProject/cve-schema), with the focus on supporting the 0.90 release (00:42:38). Michael Herzog brought up the need to finalize the JSON Schema version, noting discussions around Draft 7 versus 2020 (00:43:47).
+- **JSON Schema Version Decision** Jon Moroney mentioned that the Go library was a blocking issue for moving to Draft 2020. Michael Herzog proposed going with Draft 7 unless there are objections, as it's the most compatible version, and they can update later (00:45:29). Steve Springett added that CycloneDX is contemplating moving to 2020 for their 2.0 version but is still exploring its capabilities (00:46:16).
+- **Ajv for Strict Validation** Steve Springett mentioned using Ajv (https://github.com/ajv-validator/ajv), a JavaScript library, for strict validation of schemas in CycloneDX, which catches minor issues that most JSON parsers might ignore (00:49:51). Jon Moroney supported Ajv, noting its use in the CVE world (00:51:08).
+- **PURL Logo** Abul Hasan Sheik Madhar Ali inquired about a PURL logo for the website. Philippe Ombredanne directed them to an old issue with various logo suggestions, including some professional-looking ones from Steve Springett (https://github.com/package-url/purl-spec/issues/19), and encouraged them to mock something up (00:55:40).
+- The meeting was adjourned.


### PR DESCRIPTION
Added a .md of the minutes for 2025-07-09 and 2025-07-23 PURL community meetings.

Reference: https://github.com/package-url/purl-spec/issues/384