### PR TITLE
Fix case_sensitive property name in types

### DIFF
--- a/types/bitbucket-definition.json
+++ b/types/bitbucket-definition.json
@@ -12,12 +12,12 @@
     "requirement": "required",
     "note": "The namespace is the user or organization. It is not case sensitive and must be lowercased.",
     "native_name": "user or organization",
-    "is_case_sensitve": false
+    "case_sensitve": false
   },
   "name_definition": {
     "note": "The name is the repository name. It is not case sensitive and must be lowercased.",
     "native_name": "repository name",
-    "is_case_sensitve": false
+    "case_sensitve": false
   },
   "version_definition": {
     "note": "The version is a commit or tag.",

--- a/types/cargo-definition.json
+++ b/types/cargo-definition.json
@@ -14,7 +14,7 @@
   },
   "name_definition": {
     "native_name": "name",
-    "is_case_sensitve": true,
+    "case_sensitve": true,
     "note": "The name is the repository name."
   },
   "version_definition": {

--- a/types/cran-definition.json
+++ b/types/cran-definition.json
@@ -14,7 +14,7 @@
   },
   "name_definition": {
     "native_name": "name",
-    "is_case_sensitve": true,
+    "case_sensitve": true,
     "note": "The name is the package name and is case sensitive, but there cannot be two packages on CRAN with the same name ignoring case."
   },
   "version_definition": {

--- a/types/deb-definition.json
+++ b/types/deb-definition.json
@@ -10,13 +10,13 @@
   },
   "namespace_definition": {
     "native_name": "vendor",
-    "is_case_sensitve": false,
+    "case_sensitve": false,
     "note": "The namespace is the \"vendor\" name such as \"debian\" or \"ubuntu\". It is not case sensitive and must be lowercased.",
     "requirement": "required"
   },
   "name_definition": {
     "native_name": "name",
-    "is_case_sensitve": false,
+    "case_sensitve": false,
     "note": "The name is not case sensitive and must be lowercased."
   },
   "version_definition": {


### PR DESCRIPTION
Property is called `case_sensitive` and not `is_case_sensitive` in schema:

https://github.com/package-url/purl-spec/blob/ea4bc0c02940ea51dc1468da1abf9780b0654eb6/schemas/purl-type-definition.schema.json#L35-L40