### PR TITLE
Improved readability of Conan spec

### DIFF
--- a/types-doc/conan-definition.md
+++ b/types-doc/conan-definition.md
@@ -4,7 +4,7 @@ Do not manually edit this file. Edit the JSON type definition instead. -->
 # PURL Type Definition: conan
 
 - **Type Name:** Conan C/C++ packages
-- **Description:** Conan C/C++ packages. The purl is designed to closely resemble the Conan-native <package-name>/<package-version>@<user>/<channel> syntax for package references as specified in https://docs.conan.io/en/1.46/cheatsheet.html#package-terminology
+- **Description:** Conan C/C++ packages. The purl is designed to closely resemble the Conan-native `<package-name>/<package-version>@<user>/<channel>` syntax for package references as specified in https://docs.conan.io/en/1.46/cheatsheet.html#package-terminology
 - **Schema ID:** `https://packageurl.org/types/conan-definition.json`
 
 ## PURL Syntax
@@ -27,19 +27,19 @@ The structure of a PURL for this package type is:
 ## Name definition
 
 - **Native Label:** package-name
-- **Note:** `The Conan <package-name>.`
+- **Note:** `The Conan 'package-name'.`
 
 ## Version definition
 
 - **Native Label:** package-version
-- **Note:** `The Conan <package-version>.`
+- **Note:** `The Conan 'package-version'.`
 
 ## Qualifiers Definition
 
 | Key  | Requirement | Native name | Default Value | Description |
 |------|-------------|-------------|---------------|-------------|
-| user | Optional | user |  | The Conan <user>. Only required if the Conan package was published with <user>. |
-| channel | Optional | channel |  | The Conan <channel>. Only required if the Conan package was published with Conan <channel>. |
+| user | Optional | user |  | The Conan 'user'. Only required if the Conan package was published with 'user'. |
+| channel | Optional | channel |  | The Conan 'channel'. Only required if the Conan package was published with Conan 'channel'. |
 | rrev | Optional | recipe revision |  | The Conan recipe revision (optional). If omitted, the purl refers to the latest recipe revision available for the given version. |
 | prev | Optional | package revision |  | The Conan package revision (optional). If omitted, the purl refers to the latest package revision available for the given version and recipe revision. |
 

--- a/types/conan-definition.json
+++ b/types/conan-definition.json
@@ -3,7 +3,7 @@
   "$id": "https://packageurl.org/types/conan-definition.json",
   "type": "conan",
   "type_name": "Conan C/C++ packages",
-  "description": "Conan C/C++ packages. The purl is designed to closely resemble the Conan-native <package-name>/<package-version>@<user>/<channel> syntax for package references as specified in https://docs.conan.io/en/1.46/cheatsheet.html#package-terminology",
+  "description": "Conan C/C++ packages. The purl is designed to closely resemble the Conan-native `<package-name>/<package-version>@<user>/<channel>` syntax for package references as specified in https://docs.conan.io/en/1.46/cheatsheet.html#package-terminology",
   "repository": {
     "use_repository": true,
     "default_repository_url": "https://center.conan.io"
@@ -15,24 +15,24 @@
   },
   "name_definition": {
     "native_name": "package-name",
-    "note": "The Conan <package-name>."
+    "note": "The Conan 'package-name'."
   },
   "version_definition": {
     "native_name": "package-version",
-    "note": "The Conan <package-version>."
+    "note": "The Conan 'package-version'."
   },
   "qualifiers_definition": [
     {
       "key": "user",
       "native_name": "user",
       "requirement": "optional",
-      "description": "The Conan <user>. Only required if the Conan package was published with <user>."
+      "description": "The Conan 'user'. Only required if the Conan package was published with 'user'."
     },
     {
       "key": "channel",
       "native_name": "channel",
       "requirement": "optional",
-      "description": "The Conan <channel>. Only required if the Conan package was published with Conan <channel>."
+      "description": "The Conan 'channel'. Only required if the Conan package was published with Conan 'channel'."
     },
     {
       "key": "rrev",


### PR DESCRIPTION
When Conan components are indicated in the `<tag>` like format, they are not rendered correctly because the Markdown parser mistakes them for HTML tags.
