### PR TITLE
Request to add GetIt package manager for Delphi

### DIFF
--- a/purl-types-index.json
+++ b/purl-types-index.json
@@ -14,6 +14,7 @@
   "docker",
   "gem",
   "generic",
+  "getit",
   "github",
   "golang",
   "hackage",

--- a/tests/types/getit-test.json
+++ b/tests/types/getit-test.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://packageurl.org/schemas/purl-test.schema-1.0.json",
+  "tests": [
+    {
+      "description": "valid getit purl without qualifiers",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:getit/GroqCloudAPIwrapper@1.0",
+      "expected_output": {
+        "type": "getit",
+        "namespace": null,
+        "name": "GroqCloudAPIwrapper",
+        "version": "1.0",
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "valid getit purl with multiple qualifiers and commas in values",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:getit/AWSSDKforDelphi-12-1.4.0@1.4.0?platform=x86,x64&category=libraries,promoted",
+      "expected_output": {
+        "type": "getit",
+        "namespace": null,
+        "name": "AWSSDKforDelphi-12-1.4.0",
+        "version": "1.4.0",
+        "qualifiers": {
+          "platform": "x86,x64",
+          "category": "libraries,promoted"
+        },
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "valid getit purl with multiple qualifiers \u2014 canonical order",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:getit/AWSSDKforDelphi-12-1.4.0@1.4.0?platform=x86,x64&category=libraries,promoted",
+      "expected_output": "pkg:getit/AWSSDKforDelphi-12-1.4.0@1.4.0?category=libraries,promoted&platform=x86,x64",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "invalid getit purl without name",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:getit/@11.0?platform=ios&category=libraries",
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "name is required for getit packages"
+    },
+    {
+      "description": "Build test for getit PURL without qualifiers",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "getit",
+        "namespace": null,
+        "name": "GroqCloudAPIwrapper",
+        "version": "1.0",
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_output": "pkg:getit/GroqCloudAPIwrapper@1.0",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    }
+  ]
+}

--- a/types-doc/getit-definition.md
+++ b/types-doc/getit-definition.md
@@ -1,0 +1,50 @@
+<!--  NOTE: Auto-generated from the JSON PURL type definition.
+Do not manually edit this file. Edit the JSON type definition instead. -->
+
+# PURL Type Definition: getit
+
+- **Type Name:** GetIt
+- **Description:** Embarcadero GetIt Package Manager (Delphi & C++Builder)
+- **Schema ID:** `https://packageurl.org/types/getit-definition.json`
+
+## PURL Syntax
+
+The structure of a PURL for this package type is:
+
+    pkg:getit/<name>@<version>?<qualifiers>#<subpath>
+
+## Repository Information
+
+- **Use Repository:** Yes
+- **Default Repository URL:** https://getitnow.embarcadero.com/
+- **Note:** The repository itself is hosted on version specific REST servers, accessible via RAD Studio IDE or the CLI tool GetItCmd.exe.
+
+## Namespace definition
+
+- **Requirement:** Prohibited
+- **Note:** `GetIt packages do not use a namespace.`
+
+## Name definition
+
+- **Case Sensitive:** Yes
+- **Native Label:** Id
+- **Note:** `The name corresponds to the unique identifier (Id) of the GetIt package.`
+
+## Version definition
+
+- **Native Label:** version
+- **Note:** `The version of the GetIt package as defined in the GetIt catalog.`
+
+## Qualifiers Definition
+
+| Key  | Requirement | Native name | Default Value | Description |
+|------|-------------|-------------|---------------|-------------|
+| platform | Optional |  |  | Target platforms supported by the package (e.g., win32, win64, macos, linux, ios, android, none). Comma-separated if multiple. |
+| category | Optional |  |  | GetIt catalog category or categories (e.g., libraries, components, tools, ide-plugins, trial, promoted). Comma-separated if multiple. |
+
+## Examples
+
+- `pkg:getit/Abbrevia-12-64bit@2025.03`
+- `pkg:getit/Abbrevia-12-64bit@2025.03?platform=x86,x64&category=components`
+- `pkg:getit/GroqCloudAPIwrapper@1.0`
+- `pkg:getit/AWSSDKforDelphi-12-1.4.0@1.4.0?platform=x86,x64&category=libraries,promoted`

--- a/types/getit-definition.json
+++ b/types/getit-definition.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
+  "$id": "https://packageurl.org/types/getit-definition.json",
+  "type": "getit",
+  "type_name": "GetIt",
+  "description": "Embarcadero GetIt Package Manager (Delphi & C++Builder)",
+  "repository": {
+    "use_repository": true,
+    "default_repository_url": "https://getitnow.embarcadero.com/",
+    "note": "The repository itself is hosted on version specific REST servers, accessible via RAD Studio IDE or the CLI tool GetItCmd.exe."
+  },
+  "namespace_definition": {
+    "requirement": "prohibited",
+    "note": "GetIt packages do not use a namespace."
+  },
+  "name_definition": {
+    "case_sensitive": true,
+    "native_name": "Id",
+    "note": "The name corresponds to the unique identifier (Id) of the GetIt package."
+  },
+  "version_definition": {
+    "native_name": "version",
+    "note": "The version of the GetIt package as defined in the GetIt catalog."
+  },
+  "qualifiers_definition": [
+    {
+      "key": "platform",
+      "requirement": "optional",
+      "description": "Target platforms supported by the package (e.g., win32, win64, macos, linux, ios, android, none). Comma-separated if multiple."
+    },
+    {
+      "key": "category",
+      "requirement": "optional",
+      "description": "GetIt catalog category or categories (e.g., libraries, components, tools, ide-plugins, trial, promoted). Comma-separated if multiple."
+    }
+  ],
+  "examples": [
+    "pkg:getit/Abbrevia-12-64bit@2025.03",
+    "pkg:getit/Abbrevia-12-64bit@2025.03?platform=x86,x64&category=components",
+    "pkg:getit/GroqCloudAPIwrapper@1.0",
+    "pkg:getit/AWSSDKforDelphi-12-1.4.0@1.4.0?platform=x86,x64&category=libraries,promoted"
+  ]
+}


### PR DESCRIPTION
Hello, purl specification development team!

Please tell me, is it possible to add the Getit package manager for the Delphi language to the current specification?
If not, please tell me what might be required from us?

Relates to https://github.com/package-url/purl-spec/issues/567