### PR TITLE
Fix Schema ID URL and added missing MLflow type name

### DIFF
--- a/types-doc/alpm-definition.md
+++ b/types-doc/alpm-definition.md
@@ -5,7 +5,7 @@ Do not manually edit this file. Edit the JSON type definition instead. -->
 
 - **Type Name:** Arch Linux package
 - **Description:** Arch Linux packages and other users of the libalpm/pacman package manager.
-- **Schema ID:** `https://packageurl.org/types/github-definition.json`
+- **Schema ID:** `https://packageurl.org/types/alpm-definition.json`
 
 ## PURL Syntax
 

--- a/types-doc/apk-definition.md
+++ b/types-doc/apk-definition.md
@@ -5,7 +5,7 @@ Do not manually edit this file. Edit the JSON type definition instead. -->
 
 - **Type Name:** APK-based packages
 - **Description:** Alpine Linux APK-based packages
-- **Schema ID:** `https://packageurl.org/types/bitbucket-definition.json`
+- **Schema ID:** `https://packageurl.org/types/apk-definition.json`
 
 ## PURL Syntax
 

--- a/types-doc/bitnami-definition.md
+++ b/types-doc/bitnami-definition.md
@@ -5,7 +5,7 @@ Do not manually edit this file. Edit the JSON type definition instead. -->
 
 - **Type Name:** Bitnami
 - **Description:** Bitnami-based packages
-- **Schema ID:** `https://packageurl.org/types/bitname-definition.json`
+- **Schema ID:** `https://packageurl.org/types/bitnami-definition.json`
 
 ## PURL Syntax
 

--- a/types-doc/gem-definition.md
+++ b/types-doc/gem-definition.md
@@ -5,7 +5,7 @@ Do not manually edit this file. Edit the JSON type definition instead. -->
 
 - **Type Name:** RubyGems
 - **Description:** RubyGems
-- **Schema ID:** `https://packageurl.org/types/generic-definition.json`
+- **Schema ID:** `https://packageurl.org/types/gem-definition.json`
 
 ## PURL Syntax
 

--- a/types-doc/huggingface-definition.md
+++ b/types-doc/huggingface-definition.md
@@ -5,7 +5,7 @@ Do not manually edit this file. Edit the JSON type definition instead. -->
 
 - **Type Name:** HuggingFace models
 - **Description:** Hugging Face ML models
-- **Schema ID:** `https://packageurl.org/types/huggingfaces-definition.json`
+- **Schema ID:** `https://packageurl.org/types/huggingface-definition.json`
 
 ## PURL Syntax
 

--- a/types-doc/mlflow-definition.md
+++ b/types-doc/mlflow-definition.md
@@ -3,7 +3,7 @@ Do not manually edit this file. Edit the JSON type definition instead. -->
 
 # PURL Type Definition: mlflow
 
-- **Type Name:** 
+- **Type Name:** MLflow
 - **Description:** MLflow ML models (Azure ML, Databricks, etc.)
 - **Schema ID:** `https://packageurl.org/types/mlflow-definition.json`
 

--- a/types/alpm-definition.json
+++ b/types/alpm-definition.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
-  "$id": "https://packageurl.org/types/github-definition.json",
+  "$id": "https://packageurl.org/types/alpm-definition.json",
   "type": "alpm",
   "type_name": "Arch Linux package",
   "description": "Arch Linux packages and other users of the libalpm/pacman package manager.",

--- a/types/apk-definition.json
+++ b/types/apk-definition.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
-  "$id": "https://packageurl.org/types/bitbucket-definition.json",
+  "$id": "https://packageurl.org/types/apk-definition.json",
   "type": "apk",
   "type_name": "APK-based packages",
   "description": "Alpine Linux APK-based packages",

--- a/types/bitnami-definition.json
+++ b/types/bitnami-definition.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
-  "$id": "https://packageurl.org/types/bitname-definition.json",
+  "$id": "https://packageurl.org/types/bitnami-definition.json",
   "type": "bitnami",
   "type_name": "Bitnami",
   "description": "Bitnami-based packages",

--- a/types/gem-definition.json
+++ b/types/gem-definition.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
-  "$id": "https://packageurl.org/types/generic-definition.json",
+  "$id": "https://packageurl.org/types/gem-definition.json",
   "type": "gem",
   "type_name": "RubyGems",
   "description": "RubyGems",

--- a/types/huggingface-definition.json
+++ b/types/huggingface-definition.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
-  "$id": "https://packageurl.org/types/huggingfaces-definition.json",
+  "$id": "https://packageurl.org/types/huggingface-definition.json",
   "type": "huggingface",
   "type_name": "HuggingFace models",
   "description": "Hugging Face ML models",

--- a/types/mlflow-definition.json
+++ b/types/mlflow-definition.json
@@ -2,7 +2,7 @@
   "$schema": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
   "$id": "https://packageurl.org/types/mlflow-definition.json",
   "type": "mlflow",
-  "type_name": "",
+  "type_name": "MLflow",
   "description": "MLflow ML models (Azure ML, Databricks, etc.)",
   "repository": {
     "use_repository": true,


### PR DESCRIPTION
Fixed Schema ID URL for:

- alpm
- apk
- bitnami
- gem
- huggingface

For `mlflow` added missing `type_name`