### PR TITLE
Regenerate purl-standard.md

### DIFF
--- a/docs/standard/annex-a.md
+++ b/docs/standard/annex-a.md
@@ -8,7 +8,7 @@ is JSON Schema version draft-07 (https://json-schema.org/draft-07)
 The schema shown below is available in electronic form at:
 https://github.com/package-url/purl-spec/blob/main/schemas/purl-type-definition.schema.json
 
-```json
+```
   1 | {
   2 |   "$schema": "http://json-schema.org/draft-07/schema#",
   3 |   "$id": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
@@ -272,7 +272,7 @@ https://github.com/package-url/purl-spec/blob/main/schemas/purl-type-definition.
 The schema shown below is available in electronic form at:
 https://github.com/package-url/purl-spec/blob/main/schemas/purl-types-index.schema.json
 
-```json
+```
  1 | {
  2 |   "$schema": "http://json-schema.org/draft-07/schema#",
  3 |   "$id": "https://purl-spec.org/schemas/purl-type-index.schema-1.0.json",
@@ -291,7 +291,7 @@ https://github.com/package-url/purl-spec/blob/main/schemas/purl-types-index.sche
 The schema shown below is available in electronic form at:
 https://github.com/package-url/purl-spec/blob/main/schemas/purl-test.schema.json
 
-```json
+```
   1 | {
   2 |   "$schema": "http://json-schema.org/draft-07/schema#",
   3 |   "$id": "https://packageurl.org/schemas/purl-test.schema-1.0.json",

--- a/purl-standard.md
+++ b/purl-standard.md
@@ -40,7 +40,7 @@ development of this specification:
 
 Refer to the
 [colophon](https://ecma-tc54.github.io/ECMA-xxx-PURL/#sec-colophon) for
-more information on how this document is created.
+more information on how this document was created.
 
 # Introduction
 
@@ -210,7 +210,7 @@ implementers, and organisations involved in software composition
 analysis, dependency management, and supply chain security. PURL is
 foundational to a variety of use cases, from software bill of materials
 (SBOM) generation and license compliance to vulnerability tracking and
-software artifact exchange.
+software artefact exchange.
 
 While this document serves as the authoritative reference for
 implementing PURL, it is complemented by various ecosystem-specific
@@ -234,7 +234,7 @@ A `purl` is a URL composed of seven components:
 Components are separated by a specific character for unambiguous
 parsing.
 
-The definition for each components is:
+The definition for each component is:
 
 - **scheme**: this is the URL scheme with the constant value of “pkg”.
   One of the primary reason for this single scheme is to facilitate the
@@ -268,9 +268,9 @@ Components are designed such that they form a hierarchy from the most
 significant on the left to the least significant components on the
 right.
 
-A `purl` must NOT contain a URL Authority i.e. there is no support for
+A `purl` must not contain a URL Authority, i.e. there is no support for
 `username`, `password`, `host` and `port` components. A `namespace`
-segment may sometimes look like a `host` but its interpretation is
+segment may sometimes look like a `host`, but its interpretation is
 specific to a `type`.
 
 ## Some `purl` examples
@@ -307,17 +307,17 @@ specific to a `type`.
     are collectively mapped to a URL `path`
   - `purl` `qualifiers`: this maps to a URL `query`
   - `purl` `subpath`: this is a URL `fragment`
-  - In a `purl` there is no support for a URL Authority (e.g. NO
+  - In a `purl`, there is no support for a URL Authority (e.g. no
     `username`, `password`, `host` and `port` components).
 
 - Special URL schemes as defined in https://url.spec.whatwg.org/ such as
-  `file://`, `https://`, `http://` and `ftp://` are NOT valid `purl`
+  `file://`, `https://`, `http://` and `ftp://` are not valid `purl`
   types. They are valid URL or URI schemes but they are not `purl`. They
   may be used to reference URLs in separate attributes outside of a
   `purl` or in a `purl` qualifier.
 
 - Version control system (VCS) URLs such `git://`, `svn://`, `hg://` or
-  as defined in Python pip or SPDX download locations are NOT valid
+  as defined in Python pip or SPDX download locations are not valid
   `purl` types. They are valid URL or URI schemes but they are not
   `purl`. They are a closely related, compact and uniform way to
   reference VCS URLs. They may be used as references in separate
@@ -332,7 +332,7 @@ A canonical `purl` is composed of these permitted ASCII characters:
   ’\_’ and tilde ‘~’),
 - the Percent Character: `%` (percent sign ‘%’), and
 - the Separator Characters `:/@?=&#` (colon ‘:’, slash ‘/’, at sign ‘@’,
-  question mark ‘?’, equal sign ‘=’, ampersand ‘&’ and pound sign ‘\#’).
+  question mark ‘?’, equal sign ‘=’, ampersand ‘&’ and hash sign ‘\#’).
 
 ## 5.2 Separator Characters
 
@@ -356,9 +356,9 @@ This is how each of the Separator Characters is used:
   content.
 
 - When percent-encoding is required by a component definition, the
-  component string MUST first be encoded as UTF-8.
+  component string must first be encoded as UTF-8.
 
-- In the component string, each “data octet” MUST be replaced by the
+- In the component string, each “data octet” must be replaced by the
   percent-encoded “character triplet” applying the percent-encoding
   mechanism defined in [RFC 3986 section
   2.1](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1),
@@ -369,7 +369,7 @@ This is how each of the Separator Characters is used:
     Punctuation Characters
   - “delimiters” is composed of the Separator Characters
 
-- The following characters MUST NOT be percent-encoded:
+- The following characters must not be percent-encoded:
 
   - the Alphanumeric Characters,
   - the Punctuation Characters,
@@ -379,7 +379,7 @@ This is how each of the Separator Characters is used:
   - the percent sign ‘%’ when used to represent a percent-encoded
     character.
 
-- Where the space ’ ’ is permitted, it MUST be percent-encoded as ‘%20’.
+- Where the space ’ ’ is permitted, it must be percent-encoded as ‘%20’.
 
 - With the exception of the percent-encoding mechanism, the rules
   regarding percent-encoding are defined by this specification alone.
@@ -401,9 +401,9 @@ A `purl` string is an ASCII URL string composed of seven components.
 
 Except as expressly stated otherwise in this section, each component:
 
-- MAY be composed of any of the characters defined in the “Permitted
+- May be composed of any of the characters defined in the “Permitted
   characters” section
-- MUST be encoded as defined in the “Character encoding” section
+- Must be encoded as defined in the “Character encoding” section
 
 The “lowercase” rules are defined in the “Case folding” section.
 
@@ -412,17 +412,17 @@ The rules for each component are:
 - **scheme**:
 
   - The `scheme` is a constant with the value “pkg”.
-  - The `scheme` MUST be followed by an unencoded colon ‘:’.
-  - `purl` parsers MUST accept URLs where the `scheme` and colon ‘:’ are
+  - The `scheme` must be followed by an unencoded colon ‘:’.
+  - `purl` parsers must accept URLs where the `scheme` and colon ‘:’ are
     followed by one or more slash ‘/’ characters, such as ‘pkg://’, and
-    MUST ignore and remove all such ‘/’ characters.
+    must ignore and remove all such ‘/’ characters.
 
 - **type**:
 
-  - The package `type` MUST be composed only of ASCII letters and
+  - The package `type` must be composed only of ASCII letters and
     numbers, period ‘.’, and dash ‘-’.
-  - The `type` MUST start with an ASCII letter.
-  - The `type` MUST NOT be percent-encoded.
+  - The `type` must start with an ASCII letter.
+  - The `type` must not be percent-encoded.
   - The `type` is case insensitive. The canonical form is lowercase.
 
 - **namespace**:
@@ -430,74 +430,74 @@ The rules for each component are:
   - The `namespace` is optional, unless required by the package’s `type`
     definition.
 
-  - If present, the `namespace` MAY contain one or more segments,
+  - If present, the `namespace` may contain one or more segments,
     separated by a single unencoded slash ‘/’ character.
 
-  - All leading and trailing slashes ‘/’ are not significant and SHOULD
+  - All leading and trailing slashes ‘/’ are not significant and should
     be stripped in the canonical form. They are not part of the
     `namespace`.
 
-  - Each `namespace` segment MUST be a percent-encoded string.
+  - Each `namespace` segment must be a percent-encoded string.
 
   - When percent-decoded, a segment:
 
-    - MUST NOT contain any slash ‘/’ characters
-    - MUST NOT be empty
-    - MAY contain any Unicode character other than ‘/’ unless the
+    - Must not contain any slash ‘/’ characters
+    - Must not be empty
+    - Must contain any Unicode character other than ‘/’ unless the
       package’s `type` definition provides otherwise.
 
-  - A URL host or Authority MUST NOT be used as a `namespace`. Use
-    instead a `repository_url` qualifier. Note however that for some
+  - A URL host or Authority must not be used as a `namespace`. Use
+    instead a `repository_url` qualifier. Note however, that for some
     types, the `namespace` may look like a host.
 
 - **name**:
 
   - The `name` is prefixed by a single slash ‘/’ separator when the
     `namespace` is not empty.
-  - All leading and trailing slashes ‘/’ are not significant and SHOULD
+  - All leading and trailing slashes ‘/’ are not significant and should
     be stripped in the canonical form. They are not part of the `name`.
-  - A `name` MUST be a percent-encoded string.
-  - When percent-decoded, a `name` MAY contain any Unicode character
+  - A `name` must be a percent-encoded string.
+  - When percent-decoded, a `name` may contain any Unicode character
     unless the package’s `type` definition provides otherwise.
 
 - **version**:
 
   - The `version` is prefixed by a ‘@’ separator when not empty.
   - This ‘@’ is not part of the `version`.
-  - A `version` MUST be a percent-encoded string.
-  - When percent-decoded, a `version` MAY contain any Unicode character
+  - A `version` must be a percent-encoded string.
+  - When percent-decoded, a `version` may contain any Unicode character
     unless the package’s `type` definition provides otherwise.
   - A `version` is a plain and opaque string.
 
 - **qualifiers**:
 
-  - The `qualifiers` component MUST be prefixed by an unencoded question
+  - The `qualifiers` component must be prefixed by an unencoded question
     mark ‘?’ separator when not empty. This ‘?’ separator is not part of
     the `qualifiers` component.
 
   - The `qualifiers` component is composed of one or more `key=value`
-    pairs. Multiple `key=value` pairs MUST be separated by an unencoded
+    pairs. Multiple `key=value` pairs must be separated by an unencoded
     ampersand ‘&’. This ‘&’ separator is not part of an individual
     `qualifier`.
 
-  - A `key` and `value` MUST be separated by the unencoded equal sign
+  - A `key` and `value` must be separated by the unencoded equal sign
     ‘=’ character. This ‘=’ separator is not part of the `key` or
     `value`.
 
-  - A `value` MUST NOT be an empty string: a `key=value` pair with an
+  - A `value` must not be an empty string: a `key=value` pair with an
     empty `value` is the same as if no `key=value` pair exists for this
     `key`.
 
   - For each `key=value` pair:
 
-    - The `key` MUST be composed only of lowercase ASCII letters and
+    - The `key` must be composed only of lowercase ASCII letters and
       numbers, period ‘.’, dash ‘-’ and underscore ’\_’.
-    - A `key` MUST start with an ASCII letter.
-    - A `key` MUST NOT be percent-encoded.
-    - Each `key` MUST be unique among all the keys of the `qualifiers`
+    - A `key` must start with an ASCII letter.
+    - A `key` must not be percent-encoded.
+    - Each `key` must be unique among all the keys of the `qualifiers`
       component.
-    - A `value` MAY contain any Unicode character and all characters
-      MUST be encoded as described in the “Character encoding” section.
+    - A `value` may contain any Unicode character and all characters
+      must be encoded as described in the “Character encoding” section.
 
 - **subpath**:
 
@@ -507,23 +507,657 @@ The rules for each component are:
 
   - The `subpath` contains zero or more segments, separated by slash ‘/’
 
-  - Leading and trailing slashes ‘/’ are not significant and SHOULD be
+  - Leading and trailing slashes ‘/’ are not significant and should be
     stripped in the canonical form
 
-  - Each `subpath` segment MUST be a percent-encoded string
+  - Each `subpath` segment must be a percent-encoded string
 
   - When percent-decoded, a segment:
 
-    - MUST NOT contain any slash ‘/’ characters
-    - MUST NOT be empty
-    - MUST NOT be any of ‘..’ or ‘.’
-    - MAY contain any Unicode character other than ‘/’ unless the
+    - Must not contain any slash ‘/’ characters
+    - Must not be empty
+    - Must not be any of ‘..’ or ‘.’
+    - May contain any Unicode character other than ‘/’ unless the
       package’s `type` definition provides otherwise.
 
-  - The `subpath` MUST be interpreted as relative to the root of the
+  - The `subpath` must be interpreted as relative to the root of the
     package
 
 ## 5.6 PURL Types
 
-There are several registered `purl` package type definitions tracked in
-the separate [PURL-TYPES.rst](PURL-TYPES.rst) document.
+Each package manager, platform, type, or ecosystem has its own
+conventions and protocols to identify, locate, and provision software
+packages.
+
+The package **type** is the component of a Package-URL that is used to
+capture this information with a short string such as `maven`, `npm`,
+`nuget`, `gem`, `pypi`, etc.
+
+These are registered `PURL` package type definitions.
+
+Definitions can also include types reserved for future use.
+
+This document no longer contains a manually maintained list of PURL
+types.
+
+Instead, all PURL type definitions are now maintained in a simple JSON
+document with automatically generated documentation.
+
+## Where to find PURL Type information
+
+- In the JSON Index listing of all defined PURL types at:
+  `/purl-types-index.json <https://github.com/package-url/purl-spec/tree/main/purl-types-index.json>`\_
+
+- In individual JSON files, one for each PURL type definition at:
+  `/types <https://github.com/package-url/purl-spec/tree/main/types>`\_
+
+- As Markdown documentation, generated from for each PURL type JSON
+  definition at:
+  `/types-doc <https://github.com/package-url/purl-spec/tree/main/types-doc>`\_
+
+# A Schemas
+
+This annex provides copies of the current Package-URL schemas. The
+format is JSON Schema version draft-07
+(https://json-schema.org/draft-07)
+
+## A.1 PURL Type Definition
+
+The schema shown below is available in electronic form at:
+https://github.com/package-url/purl-spec/blob/main/schemas/purl-type-definition.schema.json
+
+``` json
+  1 | {
+  2 |   "$schema": "http://json-schema.org/draft-07/schema#",
+  3 |   "$id": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
+  4 |   "title": "Package-URL Type Definition",
+  5 |   "description": "Schema to specify a Package-URL (PURL) type as a structured definition.",
+  6 |   "type": "object",
+  7 |   "additionalProperties": false,
+  8 |   "definitions": {
+  9 |     "requirement": {
+ 10 |       "title": "Component requirement",
+ 11 |       "description": "States if this PURL component is required, optional, or prohibited.",
+ 12 |       "type": "string",
+ 13 |       "enum": [
+ 14 |         "required",
+ 15 |         "optional",
+ 16 |         "prohibited"
+ 17 |       ],
+ 18 |       "meta:enum": {
+ 19 |         "required": "This PURL component is required for this PURL type.",
+ 20 |         "optional": "This PURL component is optional for this PURL type.",
+ 21 |         "prohibited": "This PURL component is prohibited: it must not be present for this PURL type."
+ 22 |       }
+ 23 |     },
+ 24 |     "purl_component_definition": {
+ 25 |       "title": "PURL component definition",
+ 26 |       "description": "PURL component definition properties that apply to most PURL components",
+ 27 |       "type": "object",
+ 28 |       "properties": {
+ 29 |         "permitted_characters": {
+ 30 |           "title": "Permitted characters in this PURL component",
+ 31 |           "description": "Regular expression (ECMA-262 dialect) defining the 'Permitted characters' for this component of this Package-URL type. If provided, this must be a subset of the 'Permitted characters' defined in the PURL specification.",
+ 32 |           "type": "string",
+ 33 |           "format": "regex"
+ 34 |         },
+ 35 |         "case_sensitive": {
+ 36 |           "title": "Case sensitive",
+ 37 |           "description": "true if this PURL component is case sensitive. If false, the canonical form must be lowercased.",
+ 38 |           "type": "boolean",
+ 39 |           "default": true
+ 40 |         },
+ 41 |         "normalization_rules": {
+ 42 |           "title": "Normalization rules",
+ 43 |           "description": "List of rules to normalize this component for this PURL type. These are plain text, unstructured rules as some require programming and cannot be enforced only with a schema. Tools are expected to apply these rules programmatically.",
+ 44 |           "type": "array",
+ 45 |           "uniqueItems": true,
+ 46 |           "items": {
+ 47 |             "type": "string"
+ 48 |           }
+ 49 |         },
+ 50 |         "native_name": {
+ 51 |           "title": "Native name",
+ 52 |           "description": "The native name of this PURL component in the package ecosystem. For instance, the 'namespace' for the 'maven' type is 'groupId', and 'scope' for the 'npm' PURL type.",
+ 53 |           "type": "string"
+ 54 |         },
+ 55 |         "note": {
+ 56 |           "title": "Note",
+ 57 |           "description": "Extra note text.",
+ 58 |           "type": "string"
+ 59 |         }
+ 60 |       }
+ 61 |     }
+ 62 |   },
+ 63 |   "required": [
+ 64 |     "$id",
+ 65 |     "type",
+ 66 |     "type_name",
+ 67 |     "description",
+ 68 |     "repository",
+ 69 |     "namespace_definition",
+ 70 |     "name_definition",
+ 71 |     "examples"
+ 72 |   ],
+ 73 |   "properties": {
+ 74 |     "$schema": {
+ 75 |       "title": "JSON schema",
+ 76 |       "description": "Contains the URL of the JSON schema for Package-URL type definition.",
+ 77 |       "constant": "https://packageurl.org/schemas/purl-type.schema-1.0.json",
+ 78 |       "format": "uri"
+ 79 |     },
+ 80 |     "$id": {
+ 81 |       "title": "PURL type definition id",
+ 82 |       "description": "The unique identifier URI for this PURL type definition.",
+ 83 |       "type": "string",
+ 84 |       "pattern": "^https:\\/\\/packageurl\\.org/types/[a-z0-9-]+-definition\\.json$"
+ 85 |     },
+ 86 |     "type": {
+ 87 |       "title": "PURL type",
+ 88 |       "description": "The type string for this Package-URL type.",
+ 89 |       "type": "string",
+ 90 |       "pattern": "^[a-z][a-z0-9-\\.]+$",
+ 91 |       "examples": [
+ 92 |         "maven",
+ 93 |         "npm",
+ 94 |         "pypi"
+ 95 |       ]
+ 96 |     },
+ 97 |     "type_name": {
+ 98 |       "title": "Type name",
+ 99 |       "description": "The name for this PURL type.",
+100 |       "type": "string",
+101 |       "examples": [
+102 |         "Apache Maven",
+103 |         "Python Package"
+104 |       ]
+105 |     },
+106 |     "description": {
+107 |       "title": "Description",
+108 |       "description": "The description of this PURL type.",
+109 |       "type": "string"
+110 |     },
+111 |     "repository": {
+112 |       "title": "Repository",
+113 |       "description": "Package repository usage for this PURL type.",
+114 |       "type": "object",
+115 |       "additionalProperties": false,
+116 |       "required": [
+117 |         "use_repository"
+118 |       ],
+119 |       "properties": {
+120 |         "use_repository": {
+121 |           "title": "Use repository",
+122 |           "description": "true if this PURL type use a public package repository.",
+123 |           "type": "boolean",
+124 |           "default": false
+125 |         },
+126 |         "default_repository_url": {
+127 |           "title": "Default repository URL",
+128 |           "description": "The default public repository URL for this PURL type",
+129 |           "type": "string",
+130 |           "format": "uri"
+131 |         },
+132 |         "note": {
+133 |           "title": "Note",
+134 |           "description": "Extra note text.",
+135 |           "type": "string"
+136 |         }
+137 |       }
+138 |     },
+139 |     "namespace_definition": {
+140 |       "title": "Namespace definition",
+141 |       "description": "Definition of the namespace component for this PURL type.",
+142 |       "type": "object",
+143 |       "required": [
+144 |         "requirement"
+145 |       ],
+146 |       "properties": {
+147 |         "requirement": {
+148 |           "$ref": "#/definitions/requirement"
+149 |         }
+150 |       },
+151 |       "allOf": [
+152 |         {
+153 |           "$ref": "#/definitions/purl_component_definition"
+154 |         }
+155 |       ]
+156 |     },
+157 |     "name_definition": {
+158 |       "title": "Name definition",
+159 |       "description": "Definition of the name component for this PURL type.",
+160 |       "type": "object",
+161 |       "allOf": [
+162 |         {
+163 |           "$ref": "#/definitions/purl_component_definition"
+164 |         }
+165 |       ]
+166 |     },
+167 |     "version_definition": {
+168 |       "title": "Version definition",
+169 |       "description": "Definition of the version component for this PURL type.",
+170 |       "type": "object",
+171 |       "allOf": [
+172 |         {
+173 |           "$ref": "#/definitions/purl_component_definition"
+174 |         }
+175 |       ]
+176 |     },
+177 |     "qualifiers_definition": {
+178 |       "title": "Qualifiers definition",
+179 |       "description": "Definition for the qualifiers specific to this PURL type.",
+180 |       "type": "array",
+181 |       "additionalItems": false,
+182 |       "uniqueItems": true,
+183 |       "items": {
+184 |         "title": "Qualifiers definition",
+185 |         "description": "Definition of a qualifier specific to this PURL type.",
+186 |         "type": "object",
+187 |         "additionalProperties": false,
+188 |         "required": [
+189 |           "key",
+190 |           "description"
+191 |         ],
+192 |         "properties": {
+193 |           "key": {
+194 |             "title": "Qualifier key",
+195 |             "description": "The key for the qualifier.",
+196 |             "type": "string"
+197 |           },
+198 |           "requirement": {
+199 |             "$ref": "#/definitions/requirement"
+200 |           },
+201 |           "description": {
+202 |             "title": "Description",
+203 |             "description": "The description of this qualifier.",
+204 |             "type": "string"
+205 |           },
+206 |           "default_value": {
+207 |             "title": "Default value",
+208 |             "description": "The optional default value of this qualifier if not provided.",
+209 |             "type": "string"
+210 |           },
+211 |           "native_name": {
+212 |             "title": "Native name",
+213 |             "description": "The equivalent native name for this qualifier key.",
+214 |             "type": "string"
+215 |           }
+216 |         }
+217 |       }
+218 |     },
+219 |     "subpath_definition": {
+220 |       "title": "Subpath definition",
+221 |       "description": "Definition for the subpath for this PURL type.",
+222 |       "type": "object",
+223 |       "allOf": [
+224 |         {
+225 |           "$ref": "#/definitions/purl_component_definition"
+226 |         }
+227 |       ]
+228 |     },
+229 |     "examples": {
+230 |       "title": "PURL examples",
+231 |       "description": "Example of valid, canonical PURLs for this package type.",
+232 |       "type": "array",
+233 |       "uniqueItems": true,
+234 |       "minItems": 1,
+235 |       "items": {
+236 |         "type": "string",
+237 |         "pattern": "^pkg:[a-z][a-z0-9-\\.]+/.*$"
+238 |       }
+239 |     },
+240 |     "note": {
+241 |       "title": "Note",
+242 |       "description": "Note about this PURL type.",
+243 |       "type": "string"
+244 |     },
+245 |     "reference_urls": {
+246 |       "title": "Reference URLs",
+247 |       "description": "Optional list of informational reference URLs about this PURL type.",
+248 |       "type": "array",
+249 |       "uniqueItems": true,
+250 |       "items": {
+251 |         "type": "string",
+252 |         "format": "uri"
+253 |       }
+254 |     }
+255 |   }
+256 | }
+```
+
+## A.2 PURL Types Index
+
+The schema shown below is available in electronic form at:
+https://github.com/package-url/purl-spec/blob/main/schemas/purl-types-index.schema.json
+
+``` json
+ 1 | {
+ 2 |   "$schema": "http://json-schema.org/draft-07/schema#",
+ 3 |   "$id": "https://purl-spec.org/schemas/purl-type-index.schema-1.0.json",
+ 4 |   "title": "Package-URL types list.",
+ 5 |   "description": "A list of the registered Package-URL types.",
+ 6 |   "type": "array",
+ 7 |   "additionalItems": false,
+ 8 |   "items": {
+ 9 |     "type": "string"
+10 |   }
+11 | }
+```
+
+## A.3 PURL Tests
+
+The schema shown below is available in electronic form at:
+https://github.com/package-url/purl-spec/blob/main/schemas/purl-test.schema.json
+
+``` json
+  1 | {
+  2 |   "$schema": "http://json-schema.org/draft-07/schema#",
+  3 |   "$id": "https://packageurl.org/schemas/purl-test.schema-1.0.json",
+  4 |   "title": "PURL test definition",
+  5 |   "description": "Schema for Package-URL building and parsing tests with input and expected output.",
+  6 |   "type": "object",
+  7 |   "additionalProperties": false,
+  8 |   "definitions": {
+  9 |     "purl_components": {
+ 10 |       "title": "PURL decoded components",
+ 11 |       "description": "Individual decoded PURL components to use as a test input or expected output.",
+ 12 |       "type": "object",
+ 13 |       "additionalProperties": false,
+ 14 |       "properties": {
+ 15 |         "type": {
+ 16 |           "title": "PURL type",
+ 17 |           "description": "Package-URL type component.",
+ 18 |           "default": null,
+ 19 |           "type": [
+ 20 |             "string",
+ 21 |             "null"
+ 22 |           ]
+ 23 |         },
+ 24 |         "namespace": {
+ 25 |           "title": "PURL namespace",
+ 26 |           "description": "Package-URL namespace decoded component.",
+ 27 |           "default": null,
+ 28 |           "type": [
+ 29 |             "string",
+ 30 |             "null"
+ 31 |           ]
+ 32 |         },
+ 33 |         "name": {
+ 34 |           "title": "PURL name",
+ 35 |           "description": "Package-URL name decoded component.",
+ 36 |           "default": null,
+ 37 |           "type": [
+ 38 |             "string",
+ 39 |             "null"
+ 40 |           ]
+ 41 |         },
+ 42 |         "version": {
+ 43 |           "title": "PURL version",
+ 44 |           "description": "Package-URL version decoded component.",
+ 45 |           "default": null,
+ 46 |           "type": [
+ 47 |             "string",
+ 48 |             "null"
+ 49 |           ]
+ 50 |         },
+ 51 |         "qualifiers": {
+ 52 |           "title": "PURL qualifiers",
+ 53 |           "description": "Package-URL qualifiers decoded component as an object.",
+ 54 |           "default": null,
+ 55 |           "type": [
+ 56 |             "object",
+ 57 |             "null"
+ 58 |           ]
+ 59 |         },
+ 60 |         "subpath": {
+ 61 |           "title": "PURL subpath",
+ 62 |           "description": "Package-URL subpath decoded component.",
+ 63 |           "default": null,
+ 64 |           "type": [
+ 65 |             "string",
+ 66 |             "null"
+ 67 |           ]
+ 68 |         }
+ 69 |       }
+ 70 |     },
+ 71 |     "purl_test": {
+ 72 |       "title": "PURL test",
+ 73 |       "description": "A PURL test with input and expected output.",
+ 74 |       "type": "object",
+ 75 |       "required": [
+ 76 |         "description",
+ 77 |         "test_group",
+ 78 |         "test_type",
+ 79 |         "input"
+ 80 |       ],
+ 81 |       "properties": {
+ 82 |         "description": {
+ 83 |           "title": "Test description",
+ 84 |           "description": "A description for this test.",
+ 85 |           "type": "string"
+ 86 |         },
+ 87 |         "test_group": {
+ 88 |           "title": "Test group",
+ 89 |           "description": "The group of this test like 'base' or 'advanced'.",
+ 90 |           "type": "string",
+ 91 |           "enum": [
+ 92 |             "base",
+ 93 |             "advanced"
+ 94 |           ],
+ 95 |           "meta:enum": {
+ 96 |             "base": "Test group for base conformance tests for PURL building and parsing.",
+ 97 |             "advanced": "Test group for advanced tests to support flexible PURL building and parsing."
+ 98 |           }
+ 99 |         },
+100 |         "test_type": {
+101 |           "title": "Test type",
+102 |           "description": "The type of this test like 'build' or 'parse'.",
+103 |           "type": "string",
+104 |           "enum": [
+105 |             "build",
+106 |             "parse",
+107 |             "roundtrip"
+108 |           ],
+109 |           "meta:enum": {
+110 |             "build": "A PURL building test from decoded components to a canonical PURL string.",
+111 |             "parse": "A PURL building test from decoded components to a canonical PURL string.",
+112 |             "roundtrip": "A PURL routrip test, parsing then building back a PURL from a canonical string input."
+113 |           }
+114 |         },
+115 |         "expected_failure": {
+116 |           "title": "Expected failure",
+117 |           "description": "true if this test input is expected to fail to be processed.",
+118 |           "type": "boolean",
+119 |           "default": false
+120 |         },
+121 |         "expected_failure_reason": {
+122 |           "title": "Expected failure reason",
+123 |           "description": "The reason why this test is is expected to fail if expected_failure is true.",
+124 |           "default": null,
+125 |           "type": [
+126 |             "string",
+127 |             "null"
+128 |           ]
+129 |         }
+130 |       },
+131 |       "allOf": [
+132 |         {
+133 |           "if": {
+134 |             "properties": {
+135 |               "test_type": {
+136 |                 "const": "parse"
+137 |               },
+138 |               "expected_failure": {
+139 |                 "const": false
+140 |               }
+141 |             },
+142 |             "required": [
+143 |               "test_type",
+144 |               "expected_failure"
+145 |             ]
+146 |           },
+147 |           "then": {
+148 |             "properties": {
+149 |               "input": {
+150 |                 "title": "Input test PURL",
+151 |                 "description": "A PURL string to use as a test input (canonical or not).",
+152 |                 "type": "string"
+153 |               },
+154 |               "expected_output": {
+155 |                 "title": "Expected output decoded PURL components",
+156 |                 "description": "Test output as an object decoded PURL components, unless expected_failure.",
+157 |                 "$ref": "#/definitions/purl_components"
+158 |               }
+159 |             },
+160 |             "required": [
+161 |               "input",
+162 |               "expected_output"
+163 |             ]
+164 |           }
+165 |         },
+166 |         {
+167 |           "if": {
+168 |             "properties": {
+169 |               "test_type": {
+170 |                 "const": "build"
+171 |               },
+172 |               "expected_failure": {
+173 |                 "const": false
+174 |               }
+175 |             },
+176 |             "required": [
+177 |               "test_type",
+178 |               "expected_failure"
+179 |             ]
+180 |           },
+181 |           "then": {
+182 |             "properties": {
+183 |               "input": {
+184 |                 "title": "Expected output decoded PURL components",
+185 |                 "description": "Test output as an object decoded PURL components, unless expected_failure.",
+186 |                 "$ref": "#/definitions/purl_components"
+187 |               },
+188 |               "expected_output": {
+189 |                 "title": "Expected canonical PURL",
+190 |                 "description": "A canonical PURL string to use as a test ouput.",
+191 |                 "type": "string"
+192 |               }
+193 |             },
+194 |             "required": [
+195 |               "input",
+196 |               "expected_output"
+197 |             ]
+198 |           }
+199 |         },
+200 |         {
+201 |           "if": {
+202 |             "properties": {
+203 |               "test_type": {
+204 |                 "const": "roundtrip"
+205 |               }
+206 |             },
+207 |             "required": [
+208 |               "test_type"
+209 |             ]
+210 |           },
+211 |           "then": {
+212 |             "properties": {
+213 |               "input": {
+214 |                 "title": "Input test PURL",
+215 |                 "description": "A PURL string to use as a test input (canonical or not).",
+216 |                 "type": "string"
+217 |               },
+218 |               "expected_output": {
+219 |                 "title": "Expected canonical PURL",
+220 |                 "description": "A canonical PURL string to use as a test ouput.",
+221 |                 "type": "string"
+222 |               }
+223 |             },
+224 |             "required": [
+225 |               "input",
+226 |               "expected_output"
+227 |             ]
+228 |           }
+229 |         },
+230 |         {
+231 |           "if": {
+232 |             "properties": {
+233 |               "test_type": {
+234 |                 "const": "parse"
+235 |               },
+236 |               "expected_failure": {
+237 |                 "const": true
+238 |               }
+239 |             },
+240 |             "required": [
+241 |               "test_type",
+242 |               "expected_failure"
+243 |             ]
+244 |           },
+245 |           "then": {
+246 |             "properties": {
+247 |               "input": {
+248 |                 "title": "Input test PURL",
+249 |                 "description": "A PURL string to use as a test input (canonical or not).",
+250 |                 "type": "string"
+251 |               }
+252 |             },
+253 |             "required": [
+254 |               "input",
+255 |               "expected_failure_reason"
+256 |             ]
+257 |           }
+258 |         },
+259 |         {
+260 |           "if": {
+261 |             "properties": {
+262 |               "test_type": {
+263 |                 "const": "build"
+264 |               },
+265 |               "expected_failure": {
+266 |                 "const": true
+267 |               }
+268 |             },
+269 |             "required": [
+270 |               "test_type",
+271 |               "expected_failure"
+272 |             ]
+273 |           },
+274 |           "then": {
+275 |             "properties": {
+276 |               "input": {
+277 |                 "title": "Expected output decoded PURL components",
+278 |                 "description": "Test output as an object decoded PURL components, unless expected_failure.",
+279 |                 "$ref": "#/definitions/purl_components"
+280 |               }
+281 |             },
+282 |             "required": [
+283 |               "input",
+284 |               "expected_failure_reason"
+285 |             ]
+286 |           }
+287 |         }
+288 |       ]
+289 |     }
+290 |   },
+291 |   "properties": {
+292 |     "$schema": {
+293 |       "title": "JSON schema",
+294 |       "description": "Contains the URL of the JSON schema for Package-URL tests.",
+295 |       "constant": "https://packageurl.org/schemas/purl-test.schema-1.0.json",
+296 |       "format": "uri"
+297 |     },
+298 |     "tests": {
+299 |       "title": "Test suite",
+300 |       "description": "A list of Package-URL build and parse tests.",
+301 |       "additionalItems": false,
+302 |       "type": "array",
+303 |       "minItems": 1,
+304 |       "uniqueItems": true,
+305 |       "items": {
+306 |         "$ref": "#/definitions/purl_test"
+307 |       }
+308 |     }
+309 |   }
+310 | }
+```

--- a/purl-standard.md
+++ b/purl-standard.md
@@ -566,7 +566,7 @@ format is JSON Schema version draft-07
 The schema shown below is available in electronic form at:
 https://github.com/package-url/purl-spec/blob/main/schemas/purl-type-definition.schema.json
 
-``` json
+```
   1 | {
   2 |   "$schema": "http://json-schema.org/draft-07/schema#",
   3 |   "$id": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
@@ -830,7 +830,7 @@ https://github.com/package-url/purl-spec/blob/main/schemas/purl-type-definition.
 The schema shown below is available in electronic form at:
 https://github.com/package-url/purl-spec/blob/main/schemas/purl-types-index.schema.json
 
-``` json
+```
  1 | {
  2 |   "$schema": "http://json-schema.org/draft-07/schema#",
  3 |   "$id": "https://purl-spec.org/schemas/purl-type-index.schema-1.0.json",
@@ -849,7 +849,7 @@ https://github.com/package-url/purl-spec/blob/main/schemas/purl-types-index.sche
 The schema shown below is available in electronic form at:
 https://github.com/package-url/purl-spec/blob/main/schemas/purl-test.schema.json
 
-``` json
+```
   1 | {
   2 |   "$schema": "http://json-schema.org/draft-07/schema#",
   3 |   "$id": "https://packageurl.org/schemas/purl-test.schema-1.0.json",


### PR DESCRIPTION
`purl-standard.md` replaced with regenerated version using pypandoc and updated .md input files.