### PR TITLE
fix alpm jsonschema

### DIFF
--- a/types/alpm-definition.json
+++ b/types/alpm-definition.json
@@ -35,40 +35,22 @@
       "normalize version as specified in vercmp(8) at https://man.archlinux.org/man/vercmp.8#DESCRIPTION as part of alpm."
     ]
   },
-  "subpath_definition": {
-    "requirement": "prohibited",
-    "note": "The subpath component is not used for the 'alpm' purl type and must be empty."
-  },
   "qualifiers_definition": [
     {
       "key": "arch",
       "requirement": "optional",
       "native_name": "arch",
-      "description": "The arch is the qualifiers key for a package architecture.",
-      "examples": [
-        "x86_64",
-        "i686",
-        "any",
-        "arm"
-      ]
+      "description": "The arch is the qualifiers key for a package architecture."
     },
     {
       "key": "distro",
       "requirement": "optional",
-      "description": "The distribution name when using multiple distributions.",
-      "examples": [
-        "arch",
-        "manjaro",
-        "endeavouros"
-      ]
+      "description": "The distribution name when using multiple distributions."
     },
     {
       "key": "repository_url",
       "requirement": "optional",
-      "description": "Base URL for the package repository.",
-      "examples": [
-        "https://archive.archlinux.org/"
-      ]
+      "description": "Base URL for the package repository."
     }
   ],
   "examples": [


### PR DESCRIPTION
First fix PR out of several.

## Methodology

To arrive at the fixes, I trained up and utilised three separate LLMs. (Fixes are simply not possible with traditional linting and jsonschema validation tools.)

1. Qwen3-Coder - The student model struggling to understand the PURL specification based on the current jsonschemas. (Spec bugs and ambiguities are some reasons behind them.)
2. GLM-4.5 - Tasked with creating an extended version of the Package URL specification that will make it easy for all machine learning models to understand PURL.
3. Gemini-2.5-Pro - Tasked with reviewing and identifying critical flaws in the enhancements proposed by GLM-4.5.

Human was involved in the loop constantly steering and restarting the conversation threads to reduce mistakes. The result is captured in this [repo](https://github.com/AppThreat/purl4ml).

Once the enhanced version of PURL was created, Gemini-2.5-Pro was trained with this enhanced version and asked to fix the current version, strongly adhering to the current JSON schema specification.

This `methodology` section is fyi and will not be included in subsequent PRs.

## Fixes for alpm

- Fixed $id
- alpm names could [include](https://wiki.archlinux.org/title/Arch_package_guidelines) characters such as @, ., _, +, -. Enhanced the note to make the percent-encoding obvious.
- name and version have `requirement=required`
- subpath is explicitly prohibited
- Added extra `distro` and `repository_url` qualifiers. The note clearly recommends these two qualifiers but they weren't included in the definition section.
- Improved examples

NOTE: creating purl4ml and each such PR is a time consuming activity. It will take a while for me to send all PRs due to my travel.