### PR TITLE
Fixes for bitbucket

### DIFF
--- a/types/bitbucket-definition.json
+++ b/types/bitbucket-definition.json
@@ -10,20 +10,42 @@
   },
   "namespace_definition": {
     "requirement": "required",
-    "note": "The namespace is the user or organization. It is not case sensitive and must be lowercased.",
-    "native_name": "user or organization",
-    "is_case_sensitve": false
+    "note": "The namespace is the user or organization (for Bitbucket Cloud), or the Project Key (for Bitbucket Server/Data Center). It is not case sensitive and must be lowercased.",
+    "native_name": "user, organization, or project key",
+    "case_sensitive": false,
+    "normalization_rules": [
+      "It is not case sensitive and must be lowercased."
+    ]
   },
   "name_definition": {
+    "requirement": "required",
     "note": "The name is the repository name. It is not case sensitive and must be lowercased.",
     "native_name": "repository name",
-    "is_case_sensitve": false
+    "case_sensitive": false,
+    "normalization_rules": [
+      "It is not case sensitive and must be lowercased."
+    ]
   },
   "version_definition": {
-    "note": "The version is a commit or tag.",
+    "requirement": "required",
+    "note": "The version is an immutable commit hash (full or short) or a tag. Branch names (e.g., 'main') should not be used as they are mutable pointers.",
     "native_name": "commit or tag"
   },
+  "subpath_definition": {
+    "requirement": "optional",
+    "note": "The subpath is used to specify a subdirectory within the repository, which is essential for monorepos."
+  },
+  "qualifiers_definition": [
+    {
+      "key": "repository_url",
+      "requirement": "optional",
+      "description": "Custom repository URL for self-hosted Bitbucket Server/Data Center instances."
+    }
+  ],
   "examples": [
-    "pkg:bitbucket/birkenfeld/pygments-main@244fd47e07d1014f0aed9c"
+    "pkg:bitbucket/birkenfeld/pygments-main@244fd47e07d1014f0aed9c",
+    "pkg:bitbucket/atlassian/atlassian-frontend@v104.1.0",
+    "pkg:bitbucket/atlassian/atlassian-frontend@v104.1.0#packages/analytics",
+    "pkg:bitbucket/proj/internal-repo@abcdef123?repository_url=https://bitbucket.company.com"
   ]
 }


### PR DESCRIPTION
Fixes from gemini

- Corrected Typos: The non-standard attribute `is_case_sensitve` has been corrected to the standard `case_sensitive` in both the namespace_definition and name_definition.
- Required Components: The name_definition and version_definition now correctly state that they are "required" components.
- Added Normalization Rules: To enforce the lowercasing requirement, normalization_rules have been added to the namespace_definition and name_definition.
- Improved Descriptions: The native_name and note for the namespace have been updated to clarify its role for both Bitbucket Cloud (user/organization) and Server (project key). The version_definition note now explicitly warns against using mutable branch names.
- Added Subpath and Qualifiers: The schema now includes a subpath_definition to support monorepos and a qualifiers_definition for the repository_url key, which is essential for self-hosted instances.
- Enhanced Examples: The list of examples has been significantly expanded to cover various use cases, including packages identified by tags, those within a monorepo, and packages from self-hosted Bitbucket servers.
