### PR TITLE
Fixes for bitnami

### DIFF
--- a/types/bitnami-definition.json
+++ b/types/bitnami-definition.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
-  "$id": "https://packageurl.org/types/bitname-definition.json",
+  "$id": "https://packageurl.org/types/bitnami-definition.json",
   "type": "bitnami",
   "type_name": "Bitnami",
   "description": "Bitnami-based packages",
@@ -10,26 +10,33 @@
   },
   "namespace_definition": {
     "requirement": "prohibited",
-    "note": "there is no namespace"
+    "note": "There is no namespace for Bitnami packages."
   },
   "name_definition": {
+    "requirement": "required",
     "note": "The name is the component name. It must be lowercased.",
     "case_sensitive": false,
-    "native_name": "name"
+    "native_name": "name",
+    "normalization_rules": [
+      "It is not case sensitive and must be lowercased."
+    ]
   },
   "version_definition": {
+    "requirement": "optional",
     "native_name": "full package version, including version and revision",
-    "note": "The version is the full Bitnami package version, including version and revision."
+    "note": "The version is the full Bitnami package version, which follows a 'version[-revision]' format (e.g., 6.2.0 or 5.8.3-1). If omitted, the PURL refers to the latest available version for the specified distribution."
   },
   "qualifiers_definition": [
     {
       "key": "arch",
-      "description": "The arch is the qualifiers key for a package architecture. Available values are amd64 (default) and arm64.",
+      "requirement": "optional",
+      "description": "The qualifier for package architecture. The value must be one of the enumerated examples. It defaults to 'amd64' if not specified.",
       "default_value": "amd64"
     },
     {
       "key": "distro",
-      "description": "The distro is the qualifiers key for the distribution associated to the package."
+      "requirement": "required",
+      "description": "The qualifier for the Linux distribution associated with the package. This is required to uniquely identify a package artifact."
     }
   ],
   "examples": [


### PR DESCRIPTION
- Corrected Metadata: The typo in the $id has been corrected from bitname-definition.json to bitnami-definition.json.
- Defined Requirements: The name_definition is now correctly marked as "required", and the version_definition is marked as "optional". The requirements for the arch ("optional") and distro ("required") qualifiers have also been explicitly set.
- Improved Descriptions: The note for the version_definition has been expanded to clarify its format and what it means when the version is omitted.
- Added Normalization Rule: A normalization_rules field has been added to name_definition to enforce that the name must be lowercased.