### PR TITLE
Fixes for cargo

### DIFF
--- a/types/cargo-definition.json
+++ b/types/cargo-definition.json
@@ -10,17 +10,26 @@
   },
   "namespace_definition": {
     "requirement": "prohibited",
-    "note": "there is no namespace"
+    "note": "There is no namespace for Cargo packages."
   },
   "name_definition": {
+    "requirement": "required",
     "native_name": "name",
-    "is_case_sensitve": true,
-    "note": "The name is the repository name."
+    "case_sensitive": true,
+    "note": "The name is the package name. It is case-sensitive."
   },
   "version_definition": {
+    "requirement": "required",
     "native_name": "version",
-    "note": "The version is the package version."
+    "note": "The version is the package version. It should follow the Semantic Versioning (SemVer) specification."
   },
+  "qualifiers_definition": [
+    {
+      "key": "repository_url",
+      "requirement": "optional",
+      "description": "The repository URL of the registry where the package is located, if not the default crates.io."
+    }
+  ],
   "examples": [
     "pkg:cargo/rand@0.7.2",
     "pkg:cargo/clap@2.33.0",


### PR DESCRIPTION
- Corrected Typo: The non-standard attribute is_case_sensitive in name_definition has been corrected to the standard case_sensitive.
- Defined Requirements: Both the name_definition and version_definition are now correctly marked as "required", reflecting that they are mandatory components for a valid cargo purl.
- Improved Descriptions: The note fields for the name and version have been updated to be more specific. The name is clarified as the "package name," and the version note now specifies that it should follow the Semantic Versioning (SemVer) specification.
- Added Qualifiers Definition: A qualifiers_definition has been added to define the optional repository_url key, which is used to specify alternative registries for packages not hosted on crates.io.
