### PR TITLE
Fixes for cocoapods

### DIFF
--- a/types/cocoapods-definition.json
+++ b/types/cocoapods-definition.json
@@ -13,16 +13,20 @@
     "note": "there is no namespace"
   },
   "name_definition": {
+    "requirement": "required",
     "case_sensitive": true,
     "native_name": "pod name",
     "note": "The name is the pod name and is case sensitive, cannot contain whitespace, a plus (+) character, or begin with a period (.)."
   },
   "version_definition": {
+    "requirement": "required",
     "native_name": "package version",
     "note": "The version is the package version."
   },
   "subpath_definition": {
-    "note": "The purl subpath is used to represent a pods subspec (if present)."
+    "requirement": "optional",
+    "native_name": "subspec",
+    "note": "The PURL subpath is used to represent a pod's subspec. For the cocoapods type, this component is delimited by a hash (#)."
   },
   "examples": [
     "pkg:cocoapods/AFNetworking@4.0.1",


### PR DESCRIPTION
- Defined Requirements: The name_definition and version_definition are now correctly marked as "required". The subpath_definition is now defined as "optional".
- Improved Subpath Definition: The subpath_definition has been enhanced with a more specific native_name ("subspec") and an updated note that clarifies its purpose and explicitly states that it is delimited by a hash (#) character, not a slash.
