### PR TITLE
Fixes for composer

### DIFF
--- a/types/composer-definition.json
+++ b/types/composer-definition.json
@@ -12,17 +12,27 @@
     "requirement": "required",
     "case_sensitive": false,
     "native_name": "vendor",
-    "note": "The namespace is the vendor. The namespace is not case sensitive and must be lowercased."
+    "note": "The namespace is the vendor. The namespace is not case sensitive and must be lowercased.",
+    "normalization_rules": [
+      "It is not case sensitive and must be lowercased."
+    ]
   },
   "name_definition": {
+    "requirement": "required",
     "case_sensitive": false,
     "native_name": "name",
-    "note": "The name is not case sensitive and must be lowercased. Private, local packages may have no name. In this case you cannot create a purl for these."
+    "note": "The name is not case sensitive and must be lowercased. Private, local packages may have no name. In this case you cannot create a purl for these.",
+    "normalization_rules": [
+      "It is not case sensitive and must be lowercased."
+    ]
   },
   "version_definition": {
-    "native_name": "version"
+    "requirement": "required",
+    "native_name": "version",
+    "note": "The version is the package version and is a required component."
   },
   "examples": [
-    "pkg:composer/laravel/laravel@5.5.0"
+    "pkg:composer/laravel/laravel@5.5.0",
+    "pkg:composer/symfony/console@5.4.0"
   ]
 }


### PR DESCRIPTION
None of the frontier models and I can answer the question about whether the version is mandatory or not for composer! I'm assuming it is mandatory. All the tests include [version](https://github.com/package-url/purl-spec/blob/main/tests/types/composer-test.json), so reinforces the view that the version is mandatory.

- Defined Requirements: The name_definition and version_definition are now correctly marked as "required", as they are mandatory components for a valid composer purl.
- Added Normalization Rules: To enforce the lowercasing requirement, normalization_rules have been added to both the namespace_definition and name_definition.
- Improved Descriptions: The note for the version_definition has been added to state clearly that the version is a required component.
- Expanded Examples: An additional example from the reference has been included to provide better coverage.
