### PR TITLE
Fixes for conan

### DIFF
--- a/types/conan-definition.json
+++ b/types/conan-definition.json
@@ -14,10 +14,12 @@
     "note": "The vendor of the package."
   },
   "name_definition": {
+    "requirement": "required",
     "native_name": "package-name",
     "note": "The Conan <package-name>."
   },
   "version_definition": {
+    "requirement": "required",
     "native_name": "package-version",
     "note": "The Conan <package-version>."
   },
@@ -45,6 +47,41 @@
       "native_name": "package revision",
       "requirement": "optional",
       "description": "The Conan package revision (optional). If omitted, the purl refers to the latest package revision available for the given version and recipe revision."
+    },
+    {
+      "key": "arch",
+      "requirement": "optional",
+      "description": "Target architecture for the package."
+    },
+    {
+      "key": "build_type",
+      "requirement": "optional",
+      "description": "Build type configuration."
+    },
+    {
+      "key": "compiler",
+      "requirement": "optional",
+      "description": "Compiler used to build the package."
+    },
+    {
+      "key": "compiler.version",
+      "requirement": "optional",
+      "description": "Version of the compiler."
+    },
+    {
+      "key": "compiler.runtime",
+      "requirement": "optional",
+      "description": "Runtime library for the compiler."
+    },
+    {
+      "key": "os",
+      "requirement": "optional",
+      "description": "Target operating system."
+    },
+    {
+      "key": "shared",
+      "requirement": "optional",
+      "description": "Whether the package is built as a shared library."
     }
   ],
   "note": "Additional qualifiers can be used to distinguish Conan packages with different settings or options, e.g. os=Linux, build_type=Debug or shared=True. If no additional qualifiers are used to distinguish Conan packages build with different settings or options, then the purl is ambiguous and it is up to the user to work out which package is being referred to (e.g. with context information).",


### PR DESCRIPTION
Based on this [test](https://github.com/package-url/purl-spec/blob/373482246a06e86b9123d1d5ed75f2ea306e228d/tests/types/conan-test.json#L310), gemini has expanded the qualifiers definition. If this is not correct, then we should update the description in the test to say that the qualifiers are all made up.