### PR TITLE
Fixes for cran

### DIFF
--- a/types/cran-definition.json
+++ b/types/cran-definition.json
@@ -13,14 +13,17 @@
     "note": "there is no namespace"
   },
   "name_definition": {
+    "requirement": "required",
     "native_name": "name",
-    "is_case_sensitve": true,
-    "note": "The name is the package name and is case sensitive, but there cannot be two packages on CRAN with the same name ignoring case."
+    "case_sensitive": true,
+    "note": "The name is the package name. It is case-sensitive, but there cannot be two packages on CRAN with the same name ignoring case, so the canonical case MUST be used."
   },
   "version_definition": {
+    "requirement": "required",
     "native_name": "version",
     "note": "The version is the package version."
   },
+  "qualifiers_definition": [],
   "examples": [
     "pkg:cran/A3@1.0.0",
     "pkg:cran/rJava@1.0-4",


### PR DESCRIPTION
- Corrected Typo: The non-standard attribute is_case_sensitve in name_definition has been corrected to the standard case_sensitive.
- Defined Requirements: The name_definition and version_definition are now correctly marked as "required", as they are mandatory for a valid cran purl.
- Improved Name Definition: The note in the name_definition has been updated to be more specific, clarifying that while the name is case-sensitive, the canonical case spelling MUST be used because CRAN enforces case-insensitive uniqueness.
- Added Qualifiers Definition: An empty qualifiers_definition has been added to the schema to explicitly state that the cran purl type does not use any qualifiers.