### PR TITLE
README-dev: update make file targets to latest changes

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -29,6 +29,6 @@ To regenerate the Python utility model code from the JSON schemas, then regenera
 PURL type documentation from the JSON PURL type definition files, run:
 
 ```bash
-make generate
-make docs
+make gencode
+make gendocs
 ```


### PR DESCRIPTION
The make file targets have been renamed, update the README-dev to to reflect these changes.