### PR TITLE
Fix routrip typo #652

### DIFF
--- a/docs/standard/annex-a.md
+++ b/docs/standard/annex-a.md
@@ -403,7 +403,7 @@ https://github.com/package-url/purl-spec/blob/main/schemas/purl-test.schema.json
 109 |           "meta:enum": {
 110 |             "build": "A PURL building test from decoded components to a canonical PURL string.",
 111 |             "parse": "A PURL building test from decoded components to a canonical PURL string.",
-112 |             "roundtrip": "A PURL routrip test, parsing then building back a PURL from a canonical string input."
+112 |             "roundtrip": "A PURL roundtrip test, parsing then building back a PURL from a canonical string input."
 113 |           }
 114 |         },
 115 |         "expected_failure": {

--- a/purl-standard.md
+++ b/purl-standard.md
@@ -961,7 +961,7 @@ https://github.com/package-url/purl-spec/blob/main/schemas/purl-test.schema.json
 109 |           "meta:enum": {
 110 |             "build": "A PURL building test from decoded components to a canonical PURL string.",
 111 |             "parse": "A PURL building test from decoded components to a canonical PURL string.",
-112 |             "roundtrip": "A PURL routrip test, parsing then building back a PURL from a canonical string input."
+112 |             "roundtrip": "A PURL roundtrip test, parsing then building back a PURL from a canonical string input."
 113 |           }
 114 |         },
 115 |         "expected_failure": {

--- a/schemas/purl-test.schema.json
+++ b/schemas/purl-test.schema.json
@@ -109,7 +109,7 @@
           "meta:enum": {
             "build": "A PURL building test from decoded components to a canonical PURL string.",
             "parse": "A PURL building test from decoded components to a canonical PURL string.",
-            "roundtrip": "A PURL routrip test, parsing then building back a PURL from a canonical string input."
+            "roundtrip": "A PURL roundtrip test, parsing then building back a PURL from a canonical string input."
           }
         },
         "expected_failure": {


### PR DESCRIPTION
This is a simple typo fix.

Reference: https://github.com/package-url/purl-spec/issues/652