### PR TITLE
add OpenVSX

### DIFF
--- a/purl-types-index.json
+++ b/purl-types-index.json
@@ -25,6 +25,7 @@
   "npm",
   "nuget",
   "oci",
+  "openvsx",
   "pub",
   "pypi",
   "qpkg",

--- a/tests/types/openvsx-test.json
+++ b/tests/types/openvsx-test.json
@@ -1,0 +1,211 @@
+{
+  "$schema": "https://packageurl.org/schemas/purl-test.schema-1.0.json",
+  "tests": [
+    {
+      "description": "Parse test for basic OpenVSX PURL with version",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:openvsx/redhat/java@1.46.2025091308",
+      "expected_output": {
+        "type": "openvsx",
+        "namespace": "redhat",
+        "name": "java",
+        "version": "1.46.2025091308",
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Roundtrip test for basic OpenVSX PURL with version",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:openvsx/redhat/java@1.46.2025091308",
+      "expected_output": "pkg:openvsx/redhat/java@1.46.2025091308",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Build test for basic OpenVSX PURL with version",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "openvsx",
+        "namespace": "redhat",
+        "name": "java",
+        "version": "1.46.2025091308",
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_output": "pkg:openvsx/redhat/java@1.46.2025091308",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Parse test for OpenVSX PURL with platform qualifier",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:openvsx/redhat/java@1.46.2025091308?platform=linux-x64",
+      "expected_output": {
+        "type": "openvsx",
+        "namespace": "redhat",
+        "name": "java",
+        "version": "1.46.2025091308",
+        "qualifiers": {
+          "platform": "linux-x64"
+        },
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Roundtrip test for OpenVSX PURL with platform qualifier",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:openvsx/redhat/java@1.46.2025091308?platform=linux-x64",
+      "expected_output": "pkg:openvsx/redhat/java@1.46.2025091308?platform=linux-x64",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Build test for OpenVSX PURL with platform qualifier",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "openvsx",
+        "namespace": "redhat",
+        "name": "java",
+        "version": "1.46.2025091308",
+        "qualifiers": {
+          "platform": "linux-x64"
+        },
+        "subpath": null
+      },
+      "expected_output": "pkg:openvsx/redhat/java@1.46.2025091308?platform=linux-x64",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Parse test for OpenVSX PURL without version",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:openvsx/ms-python/python",
+      "expected_output": {
+        "type": "openvsx",
+        "namespace": "ms-python",
+        "name": "python",
+        "version": null,
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Roundtrip test for OpenVSX PURL without version",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:openvsx/ms-python/python",
+      "expected_output": "pkg:openvsx/ms-python/python",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Build test for OpenVSX PURL without version",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "openvsx",
+        "namespace": "microsoft",
+        "name": "python",
+        "version": null,
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_output": "pkg:openvsx/microsoft/python",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Parse test for OpenVSX PURL with darwin-arm64 platform",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:openvsx/microsoft/python@2024.10.0?platform=darwin-arm64",
+      "expected_output": {
+        "type": "openvsx",
+        "namespace": "microsoft",
+        "name": "python",
+        "version": "2024.10.0",
+        "qualifiers": {
+          "platform": "darwin-arm64"
+        },
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Parse test for OpenVSX PURL with win32-x64 platform",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:openvsx/golang/go@0.39.1?platform=win32-x64",
+      "expected_output": {
+        "type": "openvsx",
+        "namespace": "golang",
+        "name": "go",
+        "version": "0.39.1",
+        "qualifiers": {
+          "platform": "win32-x64"
+        },
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Parse test for OpenVSX PURL without namespace should fail",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:openvsx/java@1.46.2025091308",
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "OpenVSX PURLs require a namespace (publisher)"
+    },
+    {
+      "description": "Build test for OpenVSX PURL without namespace should fail",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "openvsx",
+        "namespace": null,
+        "name": "java",
+        "version": "1.46.2025091308",
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "OpenVSX PURLs require a namespace (publisher)"
+    },
+    {
+      "description": "Parse test for OpenVSX PURL with platform=universal (default)",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:openvsx/redhat/java@1.46.2025091308?platform=universal",
+      "expected_output": {
+        "type": "openvsx",
+        "namespace": "redhat",
+        "name": "java",
+        "version": "1.46.2025091308",
+        "qualifiers": {
+          "platform": "universal"
+        },
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    }
+  ]
+}

--- a/types-doc/openvsx-definition.md
+++ b/types-doc/openvsx-definition.md
@@ -1,0 +1,56 @@
+<!--  NOTE: Auto-generated from the JSON PURL type definition.
+Do not manually edit this file. Edit the JSON type definition instead. -->
+
+# PURL Type Definition: openvsx
+
+- **Type Name:** OpenVSX
+- **Description:** OpenVSX registry for VS Code extensions
+- **Schema ID:** `https://packageurl.org/types/openvsx-definition.json`
+
+## PURL Syntax
+
+The structure of a PURL for this package type is:
+
+    pkg:openvsx/<namespace>/<name>@<version>?<qualifiers>#<subpath>
+
+## Repository Information
+
+- **Use Repository:** No
+- **Note:** OpenVSX packages are only available from the official OpenVSX registry at https://open-vsx.org
+
+## Namespace definition
+
+- **Requirement:** Required
+- **Native Label:** publisher
+- **Note:** `The namespace is the publisher or vendor of the extension (e.g., 'redhat', 'microsoft')`
+
+## Name definition
+
+- **Requirement:** Required
+- **Native Label:** extension
+- **Note:** `The name is the extension identifier`
+
+## Version definition
+
+- **Requirement:** Optional
+- **Native Label:** version
+- **Note:** `The semantic version of the extension`
+
+## Qualifiers Definition
+
+| Key  | Requirement | Native name | Default Value | Description |
+|------|-------------|-------------|---------------|-------------|
+| platform | Optional | targetPlatform | universal | The target platform for the extension. Common values include 'universal', 'linux-x64', 'linux-arm64', 'darwin-x64', 'darwin-arm64', 'win32-x64', 'win32-arm64', etc. |
+
+## Examples
+
+- `pkg:openvsx/redhat/java@1.46.2025091308`
+- `pkg:openvsx/redhat/java@1.46.2025091308?platform=linux-x64`
+- `pkg:openvsx/my-python/python@2024.10.0?platform=darwin-arm64`
+- `pkg:openvsx/golang/go@0.39.1?platform=win32-x64`
+
+## Reference URLs
+
+- `https://open-vsx.org/`
+- `https://github.com/eclipse/openvsx`
+- `https://code.visualstudio.com/api/working-with-extensions/publishing-extension#platformspecific-extensions`

--- a/types/openvsx-definition.json
+++ b/types/openvsx-definition.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
+  "$id": "https://packageurl.org/types/openvsx-definition.json",
+  "type": "openvsx",
+  "type_name": "OpenVSX",
+  "description": "OpenVSX registry for VS Code extensions",
+  "repository": {
+    "use_repository": false,
+    "note": "OpenVSX packages are only available from the official OpenVSX registry at https://open-vsx.org"
+  },
+  "namespace_definition": {
+    "requirement": "required",
+    "case_sensitive": false,
+    "native_name": "publisher",
+    "note": "The namespace is the publisher or vendor of the extension (e.g., 'redhat', 'microsoft')"
+  },
+  "name_definition": {
+    "requirement": "required",
+    "case_sensitive": false,
+    "native_name": "extension",
+    "note": "The name is the extension identifier"
+  },
+  "version_definition": {
+    "requirement": "optional",
+    "case_sensitive": false,
+    "native_name": "version",
+    "note": "The semantic version of the extension"
+  },
+  "qualifiers_definition": [
+    {
+      "key": "platform",
+      "requirement": "optional",
+      "description": "The target platform for the extension. Common values include 'universal', 'linux-x64', 'linux-arm64', 'darwin-x64', 'darwin-arm64', 'win32-x64', 'win32-arm64', etc.",
+      "default_value": "universal",
+      "native_name": "targetPlatform"
+    }
+  ],
+  "examples": [
+    "pkg:openvsx/redhat/java@1.46.2025091308",
+    "pkg:openvsx/redhat/java@1.46.2025091308?platform=linux-x64",
+    "pkg:openvsx/my-python/python@2024.10.0?platform=darwin-arm64",
+    "pkg:openvsx/golang/go@0.39.1?platform=win32-x64"
+  ],
+  "reference_urls": [
+    "https://open-vsx.org/",
+    "https://github.com/eclipse/openvsx",
+    "https://code.visualstudio.com/api/working-with-extensions/publishing-extension#platformspecific-extensions"
+  ]
+}


### PR DESCRIPTION
OpenVSX is an open-source registry Extensions to VS Code Compatible Editors.

This PR adds support which takes into account extension naming patterns, along with ability to specify `platform` for some extensions which have platform-specific builds of extensions.