### PR TITLE
Add VS Code extensions

### DIFF
--- a/purl-types-index.json
+++ b/purl-types-index.json
@@ -30,5 +30,6 @@
   "qpkg",
   "rpm",
   "swid",
-  "swift"
+  "swift",
+  "vsx"
 ]

--- a/types-doc/vsx-definition.md
+++ b/types-doc/vsx-definition.md
@@ -1,0 +1,42 @@
+<!--  NOTE: Auto-generated from the JSON PURL type definition.
+Do not manually edit this file. Edit the JSON type definition instead. -->
+
+# PURL Type Definition: vsx
+
+- **Type Name:** VS Code Extension packages
+- **Description:** VS Code Extension packages
+- **Schema ID:** `https://packageurl.org/types/vsx-definition.json`
+
+## PURL Syntax
+
+The structure of a PURL for this package type is:
+
+    pkg:vsx/<namespace>/<name>@<version>?<qualifiers>#<subpath>
+
+## Repository Information
+
+- **Use Repository:** Yes
+- **Default Repository URL:** https://marketplace.visualstudio.com/vscode
+
+## Namespace definition
+
+- **Requirement:** Optional
+- **Case Sensitive:** Yes
+- **Native Label:** publisher
+
+## Name definition
+
+- **Requirement:** Required
+- **Case Sensitive:** Yes
+- **Native Label:** name
+
+## Version definition
+
+- **Requirement:** Optional
+- **Case Sensitive:** Yes
+- **Native Label:** version
+
+## Examples
+
+- `pkg:vsix/ms-python/python@2023.25.10292213`
+- `pkg:vsix/muhammad-sammy/csharp@2.15.30?repository_url=open-vsx.org`

--- a/types/vsx-definition.json
+++ b/types/vsx-definition.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
+  "$id": "https://packageurl.org/types/vsx-definition.json",
+  "type": "vsx",
+  "type_name": "VS Code Extension packages",
+  "description": "VS Code Extension packages",
+  "repository": {
+    "use_repository": true,
+    "default_repository_url": "https://marketplace.visualstudio.com/vscode"
+  },
+  "namespace_definition": {
+    "requirement": "optional",
+    "case_sensitive": true,
+    "native_name": "publisher"
+  },
+  "name_definition": {
+    "requirement": "required",
+    "case_sensitive": true,
+    "native_name": "name"
+  },
+  "version_definition": {
+    "requirement": "optional",
+    "case_sensitive": true,
+    "native_name": "version"
+  },
+  "examples": [
+    "pkg:vsix/ms-python/python@2023.25.10292213",
+    "pkg:vsix/muhammad-sammy/csharp@2.15.30?repository_url=open-vsx.org"
+  ]
+}


### PR DESCRIPTION
Related to https://github.com/package-url/purl-spec/issues/287

Clashes a little with a different approach at https://github.com/package-url/purl-spec/pull/671 since this will consider the VS Code extension marketplace as the default repository

I'm not sure that `vsx` is the right identifier, maybe `vscode` is better? The file extension for these IDE extension packages is `.vsix`.

Happy to hear & take feedback, thanks!