### PR TITLE
Add enumeration to the namespace field; adding enums for deb/rpm

### DIFF
--- a/etc/scripts/purl_type_definition.py
+++ b/etc/scripts/purl_type_definition.py
@@ -257,7 +257,7 @@ class NamespaceDefinition(PurlComponentDefinition):
     known_values: Optional[list[str]] = Field(
         None,
         description=(
-            "Optional set of allowed values for this namespace. If provided, the namespace value"
+            "Optional set of known values for this namespace. If provided, the namespace value"
             " SHOULD be one of these."
         ),
         title="Known values",

--- a/etc/scripts/purl_type_definition.py
+++ b/etc/scripts/purl_type_definition.py
@@ -254,3 +254,11 @@ class NamespaceDefinition(PurlComponentDefinition):
         ),
         title="Namespace requirement",
     )
+    valid_values: Optional[list[str]] = Field(
+        None,
+        description=(
+            "Optional set of allowed values for this namespace. If provided, the namespace value"
+            " MUST be one of these."
+        ),
+        title="Valid values",
+    )

--- a/etc/scripts/purl_type_definition.py
+++ b/etc/scripts/purl_type_definition.py
@@ -254,11 +254,11 @@ class NamespaceDefinition(PurlComponentDefinition):
         ),
         title="Namespace requirement",
     )
-    valid_values: Optional[list[str]] = Field(
+    known_values: Optional[list[str]] = Field(
         None,
         description=(
             "Optional set of allowed values for this namespace. If provided, the namespace value"
-            " MUST be one of these."
+            " SHOULD be one of these."
         ),
-        title="Valid values",
+        title="Known values",
     )

--- a/schemas/purl-type-definition.schema.json
+++ b/schemas/purl-type-definition.schema.json
@@ -163,9 +163,9 @@
             }
           ]
         },
-        "valid_values": {
-          "title": "Valid values",
-          "description": "Optional set of allowed values for this namespace. If provided, the namespace value MUST be one of these.",
+        "known_values": {
+          "title": "Known values",
+          "description": "Optional set of allowed values for this namespace. If provided, the namespace value SHOULD be one of these.",
           "type": "array",
           "items": {
             "type": "string"

--- a/schemas/purl-type-definition.schema.json
+++ b/schemas/purl-type-definition.schema.json
@@ -163,7 +163,7 @@
             }
           ]
         },
-        "known_values": {
+        "registered_values": {
           "title": "Registered values",
           "description": "Optional set of known namespace values for this package type. If provided, the namespace value should be one of these.",
           "type": "array",

--- a/schemas/purl-type-definition.schema.json
+++ b/schemas/purl-type-definition.schema.json
@@ -164,8 +164,8 @@
           ]
         },
         "known_values": {
-          "title": "Known values",
-          "description": "Optional set of known values for this namespace. If provided, the namespace value SHOULD be one of these.",
+          "title": "Registered values",
+          "description": "Optional set of known namespace values for this package type. If provided, the namespace value should be one of these.",
           "type": "array",
           "items": {
             "type": "string"

--- a/schemas/purl-type-definition.schema.json
+++ b/schemas/purl-type-definition.schema.json
@@ -162,6 +162,15 @@
               "$ref": "#/definitions/prohibited_requirement"
             }
           ]
+        },
+        "valid_values": {
+          "title": "Valid values",
+          "description": "Optional set of allowed values for this namespace. If provided, the namespace value MUST be one of these.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
         }
       },
       "allOf": [

--- a/schemas/purl-type-definition.schema.json
+++ b/schemas/purl-type-definition.schema.json
@@ -165,7 +165,7 @@
         },
         "known_values": {
           "title": "Known values",
-          "description": "Optional set of allowed values for this namespace. If provided, the namespace value SHOULD be one of these.",
+          "description": "Optional set of known values for this namespace. If provided, the namespace value SHOULD be one of these.",
           "type": "array",
           "items": {
             "type": "string"

--- a/types-doc/cpan-definition.md
+++ b/types-doc/cpan-definition.md
@@ -22,7 +22,7 @@ The structure of a PURL for this package type is:
 
 - **Requirement:** Required
 - **Native Label:** CPAN ID of the author/publisher
-- **Note:** `It MUST be written uppercase and is required.`
+- **Note:** `It MUST be written uppercase and is required`
 
 ## Name definition
 

--- a/types-doc/cpan-definition.md
+++ b/types-doc/cpan-definition.md
@@ -22,7 +22,7 @@ The structure of a PURL for this package type is:
 
 - **Requirement:** Required
 - **Native Label:** CPAN ID of the author/publisher
-- **Note:** `It MUST be written uppercase and is required`
+- **Note:** `It MUST be written uppercase and is required.`
 
 ## Name definition
 

--- a/types/deb-definition.json
+++ b/types/deb-definition.json
@@ -13,7 +13,7 @@
     "case_sensitive": false,
     "note": "The namespace is the \"vendor\" name such as \"debian\" or \"ubuntu\". It is not case sensitive and must be lowercased.",
     "requirement": "required",
-    "known_values": [
+    "registered_values": [
       "debian",
       "ubuntu"
     ]

--- a/types/deb-definition.json
+++ b/types/deb-definition.json
@@ -12,7 +12,11 @@
     "native_name": "vendor",
     "case_sensitive": false,
     "note": "The namespace is the \"vendor\" name such as \"debian\" or \"ubuntu\". It is not case sensitive and must be lowercased.",
-    "requirement": "required"
+    "requirement": "required",
+    "valid_values": [
+      "debian",
+      "ubuntu"
+    ]
   },
   "name_definition": {
     "requirement": "required",

--- a/types/deb-definition.json
+++ b/types/deb-definition.json
@@ -13,7 +13,7 @@
     "case_sensitive": false,
     "note": "The namespace is the \"vendor\" name such as \"debian\" or \"ubuntu\". It is not case sensitive and must be lowercased.",
     "requirement": "required",
-    "valid_values": [
+    "known_values": [
       "debian",
       "ubuntu"
     ]

--- a/types/rpm-definition.json
+++ b/types/rpm-definition.json
@@ -12,7 +12,18 @@
     "case_sensitive": false,
     "native_name": "vendor",
     "note": "The namespace is the vendor such as Fedora or OpenSUSE. It is not case sensitive and must be lowercased.",
-    "requirement": "required"
+    "requirement": "required",
+    "valid_values": [
+      "redhat",
+      "centos",
+      "fedora",
+      "almalinux",
+      "rockylinux",
+      "opensuse",
+      "oraclelinux",
+      "amazonlinux",
+      "azurelinux"
+    ]
   },
   "name_definition": {
     "requirement": "required",

--- a/types/rpm-definition.json
+++ b/types/rpm-definition.json
@@ -13,7 +13,7 @@
     "native_name": "vendor",
     "note": "The namespace is the vendor such as Fedora or OpenSUSE. It is not case sensitive and must be lowercased.",
     "requirement": "required",
-    "valid_values": [
+    "known_values": [
       "redhat",
       "centos",
       "fedora",

--- a/types/rpm-definition.json
+++ b/types/rpm-definition.json
@@ -13,7 +13,7 @@
     "native_name": "vendor",
     "note": "The namespace is the vendor such as Fedora or OpenSUSE. It is not case sensitive and must be lowercased.",
     "requirement": "required",
-    "known_values": [
+    "registered_values": [
       "redhat",
       "centos",
       "fedora",


### PR DESCRIPTION
# PR Changes
### adding the ability to have an enumeration given to specify valid values in the namespace field
This adds a `valid_values` optional key to the `namespace_definition` schema so that we can restrict the `namespace` field to a valid set of value

### adding those values to RPM and DEB types
I have added these specific enum values to the DEB and RPM types. 

### For Discussion
#### Non-descriptive Namespaces
It appears that some SBOM generators read the `ID` field from `/etc/os-release` which can work well sometimes (e.g., for Ubuntu it reports `ubuntu`) but in other cases it is nonsensically short (e.g., OracleLinux reports `ol`). In these cases I just opted to specify the namespace by following the convention of the others in its category, so Oracle Linux became `oraclelinux` following the form of `almalinux` and others. 


Edit: 

I have run:

```
make check
make formatjson
make gendoc

```

And it seems `make gendocs` reformatted the CPAN markdown. I don't know why. I can revert that change if needed. 