### PR TITLE
feat: Add component validation instructions

### DIFF
--- a/docs/how-to-validate-components.md
+++ b/docs/how-to-validate-components.md
@@ -1,0 +1,41 @@
+<!--
+  ~ SPDX-License-Identifier: MIT
+  -->
+## Normalization and validation of `purl` components
+
+Components produced by a conforming PURL parser are already valid and normalized.  
+However, when components come from other sources, they may require additional normalization and validation.
+
+The following rules apply (all components are assumed to be in percent-decoded form):
+
+- **type**
+    - Convert to lowercase.
+    - Validate against the allowed character set: `[a-z0-9.-]`.
+
+- **namespace** as string:
+    - Split on `/`.
+    - Normalize and validate each segment.
+
+- **namespace** segments:
+    - Remove any empty segments.
+    - Apply type-specific normalization and validation.
+
+- **name**
+    - Apply type-specific normalization and validation.
+
+- **version**
+    - Apply type-specific normalization and validation.
+
+- **qualifiers**
+    - Discard key–value pairs with an empty `value`.
+    - For each pair:
+        - Convert `key` to lowercase.
+        - Validate `key` against the allowed character set: `[a-z0-9._-]`.
+
+- **subpath** as string:
+    - Split on `/`.
+    - Normalize and validate each segment.
+
+- **subpath** segments:
+  - Remove any segment that is empty, `.` or `..`.
+  - Apply type-specific normalization and validation.


### PR DESCRIPTION
Currently, the parser specification guarantees that PURL components are output in normalized form (at least for non–type-specific rules). However, the serializer specification assumes that components may originate from external sources and therefore be invalid or unnormalized. This leads to duplication, since both the parser and serializer repeat the same normalization and validation steps.

This draft PR introduces a dedicated section that defines basic normalization and validation routines. These routines can be reused across:

* PURL parser instructions
* PURL serializer instructions
* Implementations that construct PURL objects directly from components

At this stage, the routines are presented in a standalone section. I have not yet integrated them into the parser and serializer instructions, pending feedback on their form (e.g., a simple list of rules vs. named routines similar to [WHATWG URL](https://url.spec.whatwg.org/#idna)).