### PR TITLE
Update qualifier key from 'filename' to 'file_name' #649

### DIFF
--- a/tests/types/pypi-test.json
+++ b/tests/types/pypi-test.json
@@ -96,14 +96,14 @@
       "description": "Parse test for PURL type: pypi",
       "test_group": "base",
       "test_type": "parse",
-      "input": "pkg:pypi/django@1.11.1?filename=Django-1.11.1.tar.gz",
+      "input": "pkg:pypi/django@1.11.1?file_name=Django-1.11.1.tar.gz",
       "expected_output": {
         "type": "pypi",
         "namespace": null,
         "name": "django",
         "version": "1.11.1",
         "qualifiers": {
-          "filename": "Django-1.11.1.tar.gz"
+          "file_name": "Django-1.11.1.tar.gz"
         },
         "subpath": null
       },
@@ -114,8 +114,8 @@
       "description": "Roundtrip test for PURL type: pypi",
       "test_group": "base",
       "test_type": "roundtrip",
-      "input": "pkg:pypi/django@1.11.1?filename=Django-1.11.1.tar.gz",
-      "expected_output": "pkg:pypi/django@1.11.1?filename=Django-1.11.1.tar.gz",
+      "input": "pkg:pypi/django@1.11.1?file_name=Django-1.11.1.tar.gz",
+      "expected_output": "pkg:pypi/django@1.11.1?file_name=Django-1.11.1.tar.gz",
       "expected_failure": false,
       "expected_failure_reason": null
     },
@@ -129,11 +129,11 @@
         "name": "django",
         "version": "1.11.1",
         "qualifiers": {
-          "filename": "Django-1.11.1.tar.gz"
+          "file_name": "Django-1.11.1.tar.gz"
         },
         "subpath": null
       },
-      "expected_output": "pkg:pypi/django@1.11.1?filename=Django-1.11.1.tar.gz",
+      "expected_output": "pkg:pypi/django@1.11.1?file_name=Django-1.11.1.tar.gz",
       "expected_failure": false,
       "expected_failure_reason": null
     },
@@ -141,14 +141,14 @@
       "description": "Parse test for PURL type: pypi",
       "test_group": "base",
       "test_type": "parse",
-      "input": "pkg:pypi/django@1.11.1?filename=Django-1.11.1-py2.py3-none-any.whl",
+      "input": "pkg:pypi/django@1.11.1?file_name=Django-1.11.1-py2.py3-none-any.whl",
       "expected_output": {
         "type": "pypi",
         "namespace": null,
         "name": "django",
         "version": "1.11.1",
         "qualifiers": {
-          "filename": "Django-1.11.1-py2.py3-none-any.whl"
+          "file_name": "Django-1.11.1-py2.py3-none-any.whl"
         },
         "subpath": null
       },
@@ -159,8 +159,8 @@
       "description": "Roundtrip test for PURL type: pypi",
       "test_group": "base",
       "test_type": "roundtrip",
-      "input": "pkg:pypi/django@1.11.1?filename=Django-1.11.1-py2.py3-none-any.whl",
-      "expected_output": "pkg:pypi/django@1.11.1?filename=Django-1.11.1-py2.py3-none-any.whl",
+      "input": "pkg:pypi/django@1.11.1?file_name=Django-1.11.1-py2.py3-none-any.whl",
+      "expected_output": "pkg:pypi/django@1.11.1?file_name=Django-1.11.1-py2.py3-none-any.whl",
       "expected_failure": false,
       "expected_failure_reason": null
     },
@@ -174,11 +174,11 @@
         "name": "django",
         "version": "1.11.1",
         "qualifiers": {
-          "filename": "Django-1.11.1-py2.py3-none-any.whl"
+          "file_name": "Django-1.11.1-py2.py3-none-any.whl"
         },
         "subpath": null
       },
-      "expected_output": "pkg:pypi/django@1.11.1?filename=Django-1.11.1-py2.py3-none-any.whl",
+      "expected_output": "pkg:pypi/django@1.11.1?file_name=Django-1.11.1-py2.py3-none-any.whl",
       "expected_failure": false,
       "expected_failure_reason": null
     },

--- a/types/pypi-definition.json
+++ b/types/pypi-definition.json
@@ -37,8 +37,8 @@
   ],
   "examples": [
     "pkg:pypi/django@1.11.1",
-    "pkg:pypi/django@1.11.1?filename=Django-1.11.1.tar.gz",
-    "pkg:pypi/django@1.11.1?filename=Django-1.11.1-py2.py3-none-any.whl",
+    "pkg:pypi/django@1.11.1?file_name=Django-1.11.1.tar.gz",
+    "pkg:pypi/django@1.11.1?file_name=Django-1.11.1-py2.py3-none-any.whl",
     "pkg:pypi/django-allauth@12.23"
   ]
 }


### PR DESCRIPTION
Reference: https://github.com/package-url/purl-spec/issues/649

This PR does not yet handle updating the `pypi-definition.md`.  I think I could do that manually by running `make gendocs` but I'm not certain.  

It also looks like the GH Action should handle this (see https://github.com/package-url/purl-spec/blob/main/.github/workflows/generate-index-and-docs.yml).  However, the GH Actions seem to be failing rather consistently.  https://github.com/package-url/purl-spec/actions