### PR TITLE
tests: add tests for qualifier `checksum` normalization

### DIFF
--- a/tests/spec/specification-test.json
+++ b/tests/spec/specification-test.json
@@ -143,6 +143,33 @@
       "expected_output": null,
       "expected_failure": true,
       "expected_failure_reason": "Should fail to build a PURL from invalid input components"
+    },
+    {
+      "description": "Build with normalized checksum",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "generic",
+        "namespace": null,
+        "name": "openssl",
+        "version": "1.1.10g",
+        "qualifiers": {
+          "checksum": "SHA256:dE4d501267Da"
+        },
+        "subpath": null
+      },
+      "expected_output": "pkg:generic/openssl@1.1.10g?checksum=sha256:de4d501267da",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Roundtrip with normalized checksum",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:generic/bitwarderl?checksum=SHA256:dE4d501267Da",
+      "expected_output": "pkg:generic/bitwarderl?checksum=sha256:de4d501267da",
+      "expected_failure": false,
+      "expected_failure_reason": null
     }
   ]
 }


### PR DESCRIPTION
tests for https://github.com/package-url/purl-spec/blob/d0b83304e2a5082302101750fd3001b8ece4c29b/purl-specification.md?plain=1#L592-L596

>  Each item in the `value` is in form of
  `lowercase_algorithm:hex_encoded_lowercase_value` [...]


this test checks for proper lowercasing in normalized/canonical form 