### PR TITLE
moved general tests to spec

### DIFF
--- a/tests/spec/specification-test.json
+++ b/tests/spec/specification-test.json
@@ -143,6 +143,67 @@
       "expected_output": null,
       "expected_failure": true,
       "expected_failure_reason": "Should fail to build a PURL from invalid input components"
+    },
+    {
+      "description": "checks for invalid qualifier keys",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:npm/myartifact@1.0.0?in%20production=true",
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "Should fail to parse a PURL from invalid purl input"
+    },
+    {
+      "description": "checks for invalid qualifier keys",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "npm",
+        "namespace": null,
+        "name": "myartifact",
+        "version": "1.0.0",
+        "qualifiers": {
+          "in production": "true"
+        },
+        "subpath": null
+      },
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "Should fail to build a PURL from invalid input components"
+    },
+    {
+      "description": "a name is required",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:maven/@1.3.4",
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "Should fail to parse a PURL from invalid purl input"
+    },
+    {
+      "description": "a name is required",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "maven",
+        "namespace": null,
+        "name": null,
+        "version": null,
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "Should fail to build a PURL from invalid input components"
+    },
+    {
+      "description": "invalid encoded colon : between scheme and type",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg%3Amaven/org.apache.commons/io",
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "Should fail to parse a PURL from invalid purl input"
     }
   ]
 }

--- a/tests/types/maven-test.json
+++ b/tests/types/maven-test.json
@@ -270,40 +270,6 @@
       "expected_failure_reason": null
     },
     {
-      "description": "a name is required",
-      "test_group": "base",
-      "test_type": "parse",
-      "input": "pkg:maven/@1.3.4",
-      "expected_output": null,
-      "expected_failure": true,
-      "expected_failure_reason": "Should fail to parse a PURL from invalid purl input"
-    },
-    {
-      "description": "a name is required",
-      "test_group": "base",
-      "test_type": "parse",
-      "input": "pkg:maven/@1.3.4",
-      "expected_output": null,
-      "expected_failure": true,
-      "expected_failure_reason": "Should fail to parse a PURL from invalid canonical purl input"
-    },
-    {
-      "description": "a name is required",
-      "test_group": "base",
-      "test_type": "build",
-      "input": {
-        "type": "maven",
-        "namespace": null,
-        "name": null,
-        "version": null,
-        "qualifiers": null,
-        "subpath": null
-      },
-      "expected_output": null,
-      "expected_failure": true,
-      "expected_failure_reason": "Should fail to build a PURL from invalid input components"
-    },
-    {
       "description": "slash / after type is not significant. Roundtrip an input purl to canonical.",
       "test_group": "advanced",
       "test_type": "roundtrip",
@@ -556,31 +522,6 @@
       "expected_output": "pkg:maven/mygroup/myartifact@1.0.0%20Final?mykey=my%20value",
       "expected_failure": false,
       "expected_failure_reason": null
-    },
-    {
-      "description": "invalid encoded colon : between scheme and type",
-      "test_group": "base",
-      "test_type": "parse",
-      "input": "pkg%3Amaven/org.apache.commons/io",
-      "expected_output": null,
-      "expected_failure": true,
-      "expected_failure_reason": "Should fail to parse a PURL from invalid purl input"
-    },
-    {
-      "description": "invalid encoded colon : between scheme and type",
-      "test_group": "base",
-      "test_type": "build",
-      "input": {
-        "type": "maven",
-        "namespace": "org.apache.commons",
-        "name": "io",
-        "version": null,
-        "qualifiers": null,
-        "subpath": null
-      },
-      "expected_output": null,
-      "expected_failure": true,
-      "expected_failure_reason": "Should fail to build a PURL from invalid input components"
     },
     {
       "description": "Parse test for PURL type: maven",

--- a/tests/types/npm-test.json
+++ b/tests/types/npm-test.json
@@ -52,33 +52,6 @@
       "expected_failure_reason": null
     },
     {
-      "description": "checks for invalid qualifier keys",
-      "test_group": "base",
-      "test_type": "parse",
-      "input": "pkg:npm/myartifact@1.0.0?in%20production=true",
-      "expected_output": null,
-      "expected_failure": true,
-      "expected_failure_reason": "Should fail to parse a PURL from invalid purl input"
-    },
-    {
-      "description": "checks for invalid qualifier keys",
-      "test_group": "base",
-      "test_type": "build",
-      "input": {
-        "type": "npm",
-        "namespace": null,
-        "name": "myartifact",
-        "version": "1.0.0",
-        "qualifiers": {
-          "in production": "true"
-        },
-        "subpath": null
-      },
-      "expected_output": null,
-      "expected_failure": true,
-      "expected_failure_reason": "Should fail to build a PURL from invalid input components"
-    },
-    {
       "description": "Parse test for PURL type: npm",
       "test_group": "base",
       "test_type": "parse",


### PR DESCRIPTION
since i came up with the original idea to split the test suite(#428)
so that implementations can properly test for the spec an types,
and i've spent a lot of time to properly split the actual needed spec tests, which were broadly ignored in the #514,

here are the "forgotten" and "wrong-categorized" tests.