### PR TITLE
Fix typos in golang-definition.json

### DIFF
--- a/types/golang-definition.json
+++ b/types/golang-definition.json
@@ -6,7 +6,7 @@
   "description": "Go packages",
   "repository": {
     "use_repository": true,
-    "note": "There is no default package repository, this is implied in the namespace using the go get command conventions. In practice the go module proxy acts as a public defulat repository."
+    "note": "There is no default package repository, this is implied in the namespace using the go get command conventions. In practice the Go module proxy acts as a public default repository."
   },
   "namespace_definition": {
     "requirement": "required",
@@ -22,7 +22,7 @@
     "requirement": "optional",
     "note": "The subpath is used to point to a subpath inside a package."
   },
-  "note": "the current definition predates Go modules and has several practical problems, and in particular it is impossible to determine what is a module and what is a package short of having full access to the source code or making an API call to the Go module proxy.",
+  "note": "The current definition predates Go modules and has several practical problems, and in particular it is impossible to determine what is a module and what is a package short of having full access to the source code or making an API call to the Go module proxy.",
   "version_definition": {
     "requirement": "optional",
     "note": "The version is often empty when a commit is not specified and should be the commit in most cases when available."


### PR DESCRIPTION
Reading the golang purl definition I found some minor issues to correct and increase readability.