### PR TITLE
FIX typo in specification-test.json

### DIFF
--- a/tests/spec/specification-test.json
+++ b/tests/spec/specification-test.json
@@ -203,7 +203,7 @@
       "input": "pkg%3Amaven/org.apache.commons/io",
       "expected_output": null,
       "expected_failure": true,
-      "expected_failure_reason": "Should fail to parse a PURL from invalid purl input"
+      "expected_failure_reason": "Should fail to parse a PURL from invalid purl input",
       "description": "Build with multiple checksum",
       "test_group": "base",
       "test_type": "build",


### PR DESCRIPTION
The test fails because a "comma" is missing.

```
t/99-purl-tests.t ............... 264/? Bailout called.  Further testing stopped:  t/purl/spec/specification-test.json - , or } expected while parsing object/hash, at character offset 6623 (before ""description": "Buil...") at t/99-purl-tests.t line 42.
t/99-purl-tests.t ............... Dubious, test returned 255 (wstat 65280, 0xff00)
```