### PR TITLE
remove 'invalid conan purl only namespace' testcases

### DIFF
--- a/tests/types/conan-test.json
+++ b/tests/types/conan-test.json
@@ -106,40 +106,6 @@
       "expected_failure_reason": null
     },
     {
-      "description": "invalid conan purl only namespace",
-      "test_group": "base",
-      "test_type": "parse",
-      "input": "pkg:conan/bincrafters/cctz@2.3",
-      "expected_output": null,
-      "expected_failure": true,
-      "expected_failure_reason": "Should fail to parse a PURL from invalid purl input"
-    },
-    {
-      "description": "invalid conan purl only namespace",
-      "test_group": "base",
-      "test_type": "parse",
-      "input": "pkg:conan/bincrafters/cctz@2.3",
-      "expected_output": null,
-      "expected_failure": true,
-      "expected_failure_reason": "Should fail to parse a PURL from invalid canonical purl input"
-    },
-    {
-      "description": "invalid conan purl only namespace",
-      "test_group": "base",
-      "test_type": "build",
-      "input": {
-        "type": "conan",
-        "namespace": "bincrafters",
-        "name": "cctz",
-        "version": "2.3",
-        "qualifiers": null,
-        "subpath": null
-      },
-      "expected_output": null,
-      "expected_failure": true,
-      "expected_failure_reason": "Should fail to build a PURL from invalid input components"
-    },
-    {
       "description": "invalid conan purl only channel qualifier",
       "test_group": "base",
       "test_type": "parse",


### PR DESCRIPTION
Addresses https://github.com/package-url/purl-spec/issues/731.

In the current formulation of the [conan spec](https://github.com/package-url/purl-spec/blob/3e27e9249d4bf6e9396ab99f4f8374787e430b20/types-doc/conan-definition.md?plain=1#L23) the presence of `namespace` is optional.

The testcases removed in this PR therefore make no sense.