### PR TITLE
remove 'invalid conan purl only channel qualifier' testcases

### DIFF
--- a/tests/types/conan-test.json
+++ b/tests/types/conan-test.json
@@ -106,42 +106,6 @@
       "expected_failure_reason": null
     },
     {
-      "description": "invalid conan purl only channel qualifier",
-      "test_group": "base",
-      "test_type": "parse",
-      "input": "pkg:conan/cctz@2.3?channel=stable",
-      "expected_output": null,
-      "expected_failure": true,
-      "expected_failure_reason": "Should fail to parse a PURL from invalid purl input"
-    },
-    {
-      "description": "invalid conan purl only channel qualifier",
-      "test_group": "base",
-      "test_type": "parse",
-      "input": "pkg:conan/cctz@2.3?channel=stable",
-      "expected_output": null,
-      "expected_failure": true,
-      "expected_failure_reason": "Should fail to parse a PURL from invalid canonical purl input"
-    },
-    {
-      "description": "invalid conan purl only channel qualifier",
-      "test_group": "base",
-      "test_type": "build",
-      "input": {
-        "type": "conan",
-        "namespace": null,
-        "name": "cctz",
-        "version": "2.3",
-        "qualifiers": {
-          "channel": "stable"
-        },
-        "subpath": null
-      },
-      "expected_output": null,
-      "expected_failure": true,
-      "expected_failure_reason": "Should fail to build a PURL from invalid input components"
-    },
-    {
       "description": "Parse test for PURL type: conan",
       "test_group": "base",
       "test_type": "parse",


### PR DESCRIPTION
Addresses #643 by removing testcases that don't have any apparent support in the spec.

The [channel qualifier](https://github.com/package-url/purl-spec/blob/3e27e9249d4bf6e9396ab99f4f8374787e430b20/types-doc/conan-definition.md?plain=1#L44) is an optional qualifier and so is the `pkg:conan` namespace component.

These testcases seem to suggest there being some relationship between qualifier and namespace.
A relationship that has no apparent support in the spec.