### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Context
 
 We build and release software by massively consuming and producing software
-packages such as NPMs, RPMs, Rubygems, etc.
+packages such as npm packages, RPMs, Ruby gems, etc.
 
 Each package manager, platform, type or ecosystem has its own conventions and
 protocols to identify, locate and provision software packages.
@@ -154,4 +154,4 @@ type definitions:
 
 ## Users, adopters and links
 
-See the `dedicated adopters list <ADOPTERS.md>`_.
+See the [dedicated adopters list](ADOPTERS.md).


### PR DESCRIPTION
* We can talk about an “npm package”, but not “an NPM”, since “npm” is the package manager. Similarly, “RubyGems” is a service, but the individual built packages are “Ruby gems”.
* The link at the bottom had garbled markdown.