### PR TITLE
update tests.md to match v0.1 test schema

### DIFF
--- a/docs/tests.md
+++ b/docs/tests.md
@@ -8,7 +8,7 @@ to the PURL specification for tool functions such as:
 - parse a canonical PURL string into a set of PURL components
 - parse a PURL string input and rebuild it as a canonical PURL string
 
-The current  JSON schema is available at: [`purl-spec/schemas/purl-test.schema-0.1.json`](https://github.com/package-url/purl-spec/blob/main/schemas/purl-type-definition.schema-1.0.json).
+The current  JSON schema is available at: [`purl-spec/schemas/purl-test.schema-0.1.json`](https://github.com/package-url/purl-spec/blob/main/schemas/purl-test.schema-0.1.json).
 
 The test files are available at:
 - [`purl-spec/tests/spec/`](https://github.com/package-url/purl-spec/tree/main/tests/spec): 
@@ -38,8 +38,7 @@ permissive than base tests. They may correct some errors.
 There are three PURL test types:
 - **build**: A test to build a canonical PURL output string from an input of 
 decoded PURL components. See also [`/docs/how-build.md`](https://github.com/package-url/purl-spec/blob/main/docs/how-to-build.md).
-- **parse**: A test to parse decoded components from a canonical PURL 
-input string. See also [`/docs/how-parse.md`](https://github.com/package-url/purl-spec/blob/main/docs/how-to-parse.md).
+- **parse**: A test to parse a PURL input string into a set of decoded components. See also [`/docs/how-parse.md`](https://github.com/package-url/purl-spec/blob/main/docs/how-to-parse.md).
 - **roundtrip**: A test to parse an input PURL string and then rebuild it as a
  canonical PURL output string.
 

--- a/schemas/purl-test.schema-0.1.json
+++ b/schemas/purl-test.schema-0.1.json
@@ -108,7 +108,7 @@
           ],
           "meta:enum": {
             "build": "A test to build a canonical PURL output string from an input of decoded PURL components.",
-            "parse": A test to parse decoded components from a PURL input string.",
+            "parse": "A test to parse a PURL input string into a set of decoded components.",
             "roundtrip": "A test to produce a canonical PURL output string from an input PURL string."
           }
         },


### PR DESCRIPTION
This PR includes editorial fixes for the description of test types in `schemas/purl-test.schema-0.1.json` and rewrites tests.md to match and explain the content of `schemas/purl-test.schema-0.1.json`