### PR TITLE
yocto: Fix project name

### DIFF
--- a/types-doc/yocto-definition.md
+++ b/types-doc/yocto-definition.md
@@ -3,8 +3,8 @@ Do not manually edit this file. Edit the JSON type definition instead. -->
 
 # PURL Type Definition: yocto
 
-- **Type Name:** Yocto Linux
-- **Description:** Yocto Linux recipes
+- **Type Name:** Yocto Project
+- **Description:** Yocto Project recipes
 - **Schema ID:** `https://packageurl.org/types/yocto-definition.json`
 
 ## PURL Syntax

--- a/types/yocto-definition.json
+++ b/types/yocto-definition.json
@@ -2,8 +2,8 @@
   "$schema": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
   "$id": "https://packageurl.org/types/yocto-definition.json",
   "type": "yocto",
-  "type_name": "Yocto Linux",
-  "description": "Yocto Linux recipes",
+  "type_name": "Yocto Project",
+  "description": "Yocto Project recipes",
   "repository": {
     "use_repository": true,
     "requirement": "optional",


### PR DESCRIPTION
Per Yocto branding guidelines, the name of the project is "Yocto Project" not "Yocto Linux"