### PR TITLE
Create spec for the Image Packaging System IPS for OpenSolaris descendant systems

### DIFF
--- a/purl-types-index.json
+++ b/purl-types-index.json
@@ -20,6 +20,7 @@
   "hackage",
   "hex",
   "huggingface",
+  "ips",
   "julia",
   "luarocks",
   "maven",

--- a/tests/types/ips-test.json
+++ b/tests/types/ips-test.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://packageurl.org/schemas/purl-test.schema-0.1.json",
+  "tests": [
+    {
+      "description": "ips package with publisher and hierarchical name",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:ips/openindiana.org/system%2flibrary@0.5.11,5.11-2023.0.0.20163:20230504T155427Z",
+      "expected_output": {
+        "type": "ips",
+        "namespace": "openindiana.org",
+        "name": "system/library",
+        "version": "0.5.11,5.11-2023.0.0.20163:20230504T155427Z",
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "ips package roundtrip",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:ips/openindiana.org/system%2flibrary@0.5.11,5.11-2023.0.0.20163:20230504T155427Z",
+      "expected_output": "pkg:ips/openindiana.org/system%2flibrary@0.5.11,5.11-2023.0.0.20163:20230504T155427Z",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "ips package build",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "ips",
+        "namespace": "openindiana.org",
+        "name": "system/library",
+        "version": "0.5.11,5.11-2023.0.0.20163:20230504T155427Z",
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_output": "pkg:ips/openindiana.org/system%2flibrary@0.5.11,5.11-2023.0.0.20163:20230504T155427Z",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "ips package with architecture qualifier",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:ips/omnios/runtime%2fperl-532@5.32.1,5.11-151038.0:20210503T104523Z?arch=i386",
+      "expected_output": {
+        "type": "ips",
+        "namespace": "omnios",
+        "name": "runtime/perl-532",
+        "version": "5.32.1,5.11-151038.0:20210503T104523Z",
+        "qualifiers": {
+          "arch": "i386"
+        },
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "ips package without publisher",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:ips/developer%2fgcc-10@10.3.0,5.11-151038.0:20210503T104523Z",
+      "expected_output": {
+        "type": "ips",
+        "namespace": null,
+        "name": "developer/gcc-10",
+        "version": "10.3.0,5.11-151038.0:20210503T104523Z",
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "ips package without namespace",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:ips/bash@4.4",
+      "expected_output": {
+        "type": "ips",
+        "namespace": null,
+        "name": "bash",
+        "version": "4.4",
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    }
+  ]
+}

--- a/types-doc/ips-definition.md
+++ b/types-doc/ips-definition.md
@@ -1,0 +1,53 @@
+<!--  NOTE: Auto-generated from the JSON PURL type definition.
+Do not manually edit this file. Edit the JSON type definition instead. -->
+
+# PURL Type Definition: ips
+
+- **Type Name:** IPS
+- **Description:** Image Packaging System (IPS) packages used in illumos and Solaris distributions.
+- **Schema ID:** `https://packageurl.org/types/ips-definition.json`
+
+## PURL Syntax
+
+The structure of a PURL for this package type is:
+
+    pkg:ips/<namespace>/<name>@<version>?<qualifiers>#<subpath>
+
+## Repository Information
+
+- **Use Repository:** Yes
+- **Note:** There is no default package repository. The publisher in the namespace or a repository_url qualifier should be used to identify the source of the package.
+
+## Namespace definition
+
+- **Requirement:** Optional
+- **Normalization rules:**
+  - It is not case sensitive and must be lowercased.
+- **Native Label:** publisher
+- **Note:** `The namespace is the IPS publisher name.`
+
+## Name definition
+
+- **Requirement:** Required
+- **Normalization rules:**
+  - It is not case sensitive and must be lowercased.
+- **Native Label:** package name
+- **Note:** `The name is the IPS package name. If the package name contains slashes, they must be percent-encoded as %2f.`
+
+## Version definition
+
+- **Requirement:** Optional
+- **Native Label:** version
+- **Note:** `The version is the IPS package version FMRI component.`
+
+## Qualifiers Definition
+
+| Key  | Requirement | Native name | Default Value | Description |
+|------|-------------|-------------|---------------|-------------|
+| arch | Optional |  |  | The CPU architecture of the package. |
+
+## Examples
+
+- `pkg:ips/openindiana.org/system%2flibrary@0.5.11,5.11-2023.0.0.20163:20230504T155427Z`
+- `pkg:ips/omnios/runtime%2fperl-532@5.32.1,5.11-151038.0:20210503T104523Z`
+- `pkg:ips/library%2fpython%2fnumpy@1.21.2,5.11-151038.0:20210503T104523Z`

--- a/types/ips-definition.json
+++ b/types/ips-definition.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
+  "$id": "https://packageurl.org/types/ips-definition.json",
+  "type": "ips",
+  "type_name": "IPS",
+  "description": "Image Packaging System (IPS) packages used in illumos and Solaris distributions.",
+  "repository": {
+    "use_repository": true,
+    "note": "There is no default package repository. The publisher in the namespace or a repository_url qualifier should be used to identify the source of the package."
+  },
+  "namespace_definition": {
+    "native_name": "publisher",
+    "requirement": "optional",
+    "case_sensitive": false,
+    "note": "The namespace is the IPS publisher name.",
+    "normalization_rules": [
+      "It is not case sensitive and must be lowercased."
+    ]
+  },
+  "name_definition": {
+    "native_name": "package name",
+    "requirement": "required",
+    "case_sensitive": false,
+    "note": "The name is the IPS package name. If the package name contains slashes, they must be percent-encoded as %2f.",
+    "normalization_rules": [
+      "It is not case sensitive and must be lowercased."
+    ]
+  },
+  "version_definition": {
+    "native_name": "version",
+    "requirement": "optional",
+    "note": "The version is the IPS package version FMRI component."
+  },
+  "qualifiers_definition": [
+    {
+      "key": "arch",
+      "description": "The CPU architecture of the package."
+    }
+  ],
+  "examples": [
+    "pkg:ips/openindiana.org/system%2flibrary@0.5.11,5.11-2023.0.0.20163:20230504T155427Z",
+    "pkg:ips/omnios/runtime%2fperl-532@5.32.1,5.11-151038.0:20210503T104523Z",
+    "pkg:ips/library%2fpython%2fnumpy@1.21.2,5.11-151038.0:20210503T104523Z"
+  ]
+}


### PR DESCRIPTION
This add the needed specifications to the PURL spec to handle IPS FMRI's as PURL's. In most cases external services want to use full FMRI's to read dependencies but may provide a PURL with partial FMRI for the System to use it's rules to find the package in the same way a user can ask for installing gcc-10 and does not have to specify the full FMRI.