### PR TITLE
yocto testcase purl uses wrong separator for qualifiers

### DIFF
--- a/tests/types/yocto-test.json
+++ b/tests/types/yocto-test.json
@@ -5,7 +5,7 @@
       "description": "basic yocto recipe test",
       "test_group": "base",
       "test_type": "parse",
-      "input": "pkg:yocto/core/glibc@2.35&repository_url=https:%2F%2Fgit.openembedded.org%2Fopenembedded-core&layer_version=kirkstone",
+      "input": "pkg:yocto/core/glibc@2.35?repository_url=https:%2F%2Fgit.openembedded.org%2Fopenembedded-core&layer_version=kirkstone",
       "expected_output": {
         "type": "yocto",
         "namespace": "core",


### PR DESCRIPTION
The testcase uses `&` to separate version from qualifiers, which of course is incorrect. Qualifiers are separated from version by a `?`.