### PR TITLE
Add agent skills purl type

### DIFF
--- a/purl-types-index.json
+++ b/purl-types-index.json
@@ -1,4 +1,5 @@
 [
+  "agentskills",
   "alpm",
   "apk",
   "bazel",

--- a/tests/types/agentskills-test.json
+++ b/tests/types/agentskills-test.json
@@ -1,0 +1,261 @@
+{
+  "$schema": "https://packageurl.org/schemas/purl-test.schema-0.1.json",
+  "tests": [
+    {
+      "description": "Parse a simple agentskills PURL without version",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:agentskills/anthropics/xlsx",
+      "expected_output": {
+        "type": "agentskills",
+        "namespace": "anthropics",
+        "name": "xlsx",
+        "version": null,
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Roundtrip a simple agentskills PURL without version",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:agentskills/anthropics/xlsx",
+      "expected_output": "pkg:agentskills/anthropics/xlsx",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Build a simple agentskills PURL without version",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "agentskills",
+        "namespace": "anthropics",
+        "name": "xlsx",
+        "version": null,
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_output": "pkg:agentskills/anthropics/xlsx",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Parse an agentskills PURL with a git commit version",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:agentskills/anthropics/theme-factory@d211d437",
+      "expected_output": {
+        "type": "agentskills",
+        "namespace": "anthropics",
+        "name": "theme-factory",
+        "version": "d211d437",
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Roundtrip an agentskills PURL with a git commit version",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:agentskills/anthropics/theme-factory@d211d437",
+      "expected_output": "pkg:agentskills/anthropics/theme-factory@d211d437",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Build an agentskills PURL with a git commit version",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "agentskills",
+        "namespace": "anthropics",
+        "name": "theme-factory",
+        "version": "d211d437",
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_output": "pkg:agentskills/anthropics/theme-factory@d211d437",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Parse a ClawHub-hosted agentskills PURL with semantic version and repository_url",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:agentskills/openclaw-community/weather@1.2.0?repository_url=https://clawhub.ai",
+      "expected_output": {
+        "type": "agentskills",
+        "namespace": "openclaw-community",
+        "name": "weather",
+        "version": "1.2.0",
+        "qualifiers": {
+          "repository_url": "https://clawhub.ai"
+        },
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Roundtrip a ClawHub-hosted agentskills PURL",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:agentskills/openclaw-community/weather@1.2.0?repository_url=https://clawhub.ai",
+      "expected_output": "pkg:agentskills/openclaw-community/weather@1.2.0?repository_url=https://clawhub.ai",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Build a ClawHub-hosted agentskills PURL",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "agentskills",
+        "namespace": "openclaw-community",
+        "name": "weather",
+        "version": "1.2.0",
+        "qualifiers": {
+          "repository_url": "https://clawhub.ai"
+        },
+        "subpath": null
+      },
+      "expected_output": "pkg:agentskills/openclaw-community/weather@1.2.0?repository_url=https://clawhub.ai",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Parse an agentskills PURL with scope qualifier",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:agentskills/microsoft/mcp-builder?scope=user",
+      "expected_output": {
+        "type": "agentskills",
+        "namespace": "microsoft",
+        "name": "mcp-builder",
+        "version": null,
+        "qualifiers": {
+          "scope": "user"
+        },
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Roundtrip an agentskills PURL with scope qualifier",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:agentskills/microsoft/mcp-builder?scope=user",
+      "expected_output": "pkg:agentskills/microsoft/mcp-builder?scope=user",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Build an agentskills PURL with scope qualifier",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "agentskills",
+        "namespace": "microsoft",
+        "name": "mcp-builder",
+        "version": null,
+        "qualifiers": {
+          "scope": "user"
+        },
+        "subpath": null
+      },
+      "expected_output": "pkg:agentskills/microsoft/mcp-builder?scope=user",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Parse an agentskills PURL with scope and client qualifiers",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:agentskills/vercel-labs/deploy-to-vercel?client=claude-code&scope=project",
+      "expected_output": {
+        "type": "agentskills",
+        "namespace": "vercel-labs",
+        "name": "deploy-to-vercel",
+        "version": null,
+        "qualifiers": {
+          "client": "claude-code",
+          "scope": "project"
+        },
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Roundtrip an agentskills PURL with scope and client qualifiers",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:agentskills/vercel-labs/deploy-to-vercel?client=claude-code&scope=project",
+      "expected_output": "pkg:agentskills/vercel-labs/deploy-to-vercel?client=claude-code&scope=project",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Build an agentskills PURL with scope and client qualifiers",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "agentskills",
+        "namespace": "vercel-labs",
+        "name": "deploy-to-vercel",
+        "version": null,
+        "qualifiers": {
+          "client": "claude-code",
+          "scope": "project"
+        },
+        "subpath": null
+      },
+      "expected_output": "pkg:agentskills/vercel-labs/deploy-to-vercel?client=claude-code&scope=project",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "agentskills namespace should be lowercased",
+      "test_group": "advanced",
+      "test_type": "roundtrip",
+      "input": "pkg:agentskills/Anthropics/xlsx",
+      "expected_output": "pkg:agentskills/anthropics/xlsx",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Parse an agentskills PURL with install_path qualifier",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:agentskills/internal/deploy?install_path=.agents/skills/deploy&scope=project",
+      "expected_output": {
+        "type": "agentskills",
+        "namespace": "internal",
+        "name": "deploy",
+        "version": null,
+        "qualifiers": {
+          "install_path": ".agents/skills/deploy",
+          "scope": "project"
+        },
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "Roundtrip an agentskills PURL with install_path qualifier",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:agentskills/internal/deploy?install_path=.agents/skills/deploy&scope=project",
+      "expected_output": "pkg:agentskills/internal/deploy?install_path=.agents/skills/deploy&scope=project",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    }
+  ]
+}

--- a/types-doc/agentskills-definition.md
+++ b/types-doc/agentskills-definition.md
@@ -1,0 +1,67 @@
+<!--  NOTE: Auto-generated from the JSON PURL type definition.
+Do not manually edit this file. Edit the JSON type definition instead. -->
+
+# PURL Type Definition: agentskills
+
+- **Type Name:** Agent Skills
+- **Description:** AI agent skills following the Agent Skills specification (SKILL.md format)
+- **Schema ID:** `https://packageurl.org/types/agentskills-definition.json`
+
+## PURL Syntax
+
+The structure of a PURL for this package type is:
+
+    pkg:agentskills/<namespace>/<name>@<version>?<qualifiers>#<subpath>
+
+## Repository Information
+
+- **Use Repository:** Yes
+- **Default Repository URL:** https://github.com
+- **Note:** `The default repository is GitHub, where most agent skills are published. Other registries such as ClawHub (clawhub.ai) can be specified using the repository_url qualifier.`
+
+## Namespace definition
+
+- **Requirement:** Required
+- **Native Label:** owner or publisher
+- **Note:** `The namespace is the skill publisher or repository owner. For GitHub-hosted skills, this is the GitHub user or organization (e.g., 'anthropics', 'microsoft'). For ClawHub skills, this is the publisher name. When a skill is discovered in the cross-client path (.agents/skills/) and the publisher cannot be determined from provenance files, use the reserved namespace 'cross-client'. It is not case sensitive and must be lowercased.`
+
+## Name definition
+
+- **Requirement:** Required
+- **Native Label:** skill name
+- **Note:** `The name is the skill name as defined in the SKILL.md frontmatter 'name' field. Skill names may only contain lowercase letters, numbers, and hyphens per the Agent Skills specification. Must not start or end with a hyphen or contain consecutive hyphens.`
+
+## Version definition
+
+- **Requirement:** Optional
+- **Native Label:** version or commit
+- **Note:** `The version is the skill version if available. May be a semantic version from a registry lock file (e.g., clawhub.lock), a git commit SHA, or a git tag. Versions are optional as many skills do not declare an explicit version in their SKILL.md frontmatter.`
+
+## Qualifiers definition
+
+| Key | Description |
+|-----|-------------|
+| `repository_url` | The URL of the skill registry or repository when not using the default GitHub repository. For example, 'https://clawhub.ai' for ClawHub-hosted skills. |
+| `install_path` | The filesystem path where the skill is installed, relative to the scan root. For example, '.agents/skills/weather' or '.claude/skills/lint-fix'. |
+| `scope` | The installation scope of the skill: 'project' for project-level skills or 'user' for user/global-level skills. |
+| `client` | The target agent client for client-specific skill paths. For example, 'claude-code', 'cursor', 'windsurf', 'openclaw', 'fast-agent'. Skills in cross-client paths (.agents/skills/) do not require this qualifier. |
+
+## Examples
+
+- `pkg:agentskills/anthropics/xlsx`
+- `pkg:agentskills/anthropics/theme-factory@d211d437`
+- `pkg:agentskills/openclaw-community/weather@1.2.0?repository_url=https://clawhub.ai`
+- `pkg:agentskills/microsoft/mcp-builder?scope=user`
+- `pkg:agentskills/vercel-labs/deploy-to-vercel?scope=project&client=claude-code`
+- `pkg:agentskills/internal/deploy?scope=project&install_path=.agents/skills/deploy`
+- `pkg:agentskills/cross-client/data-pipeline?scope=user`
+
+## Agent Skills Specification
+
+This PURL type identifies packages conforming to the [Agent Skills specification](https://agentskills.io/specification), an open format for giving AI agents new capabilities. A skill is a directory containing a `SKILL.md` file with YAML frontmatter (`name`, `description`) and Markdown instructions, optionally bundled with scripts, references, and assets.
+
+## Reference URLs
+
+- [Agent Skills Specification](https://agentskills.io/specification)
+- [Client Implementation Guide](https://agentskills.io/client-implementation/adding-skills-support)
+- [Agent Skills GitHub Repository](https://github.com/agentskills/agentskills)

--- a/types/agentskills-definition.json
+++ b/types/agentskills-definition.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
+  "$id": "https://packageurl.org/types/agentskills-definition.json",
+  "type": "agentskills",
+  "type_name": "Agent Skills",
+  "description": "AI agent skills following the Agent Skills specification (SKILL.md format)",
+  "repository": {
+    "use_repository": true,
+    "default_repository_url": "https://github.com",
+    "note": "The default repository is GitHub, where most agent skills are published. Other registries such as ClawHub (clawhub.ai) can be specified using the repository_url qualifier."
+  },
+  "namespace_definition": {
+    "requirement": "required",
+    "case_sensitive": false,
+    "native_name": "owner or publisher",
+    "note": "The namespace is the skill publisher or repository owner. For GitHub-hosted skills, this is the GitHub user or organization (e.g., 'anthropics', 'microsoft'). For ClawHub skills, this is the publisher name. When a skill is discovered in the cross-client path (.agents/skills/) and the publisher cannot be determined from provenance files, use the reserved namespace 'cross-client'. It is not case sensitive and must be lowercased."
+  },
+  "name_definition": {
+    "requirement": "required",
+    "case_sensitive": true,
+    "native_name": "skill name",
+    "note": "The name is the skill name as defined in the SKILL.md frontmatter 'name' field. Skill names may only contain lowercase letters, numbers, and hyphens per the Agent Skills specification. Must not start or end with a hyphen or contain consecutive hyphens."
+  },
+  "version_definition": {
+    "requirement": "optional",
+    "native_name": "version or commit",
+    "note": "The version is the skill version if available. May be a semantic version from a registry lock file (e.g., clawhub.lock), a git commit SHA, or a git tag. Versions are optional as many skills do not declare an explicit version in their SKILL.md frontmatter."
+  },
+  "qualifiers_definition": [
+    {
+      "key": "repository_url",
+      "description": "The URL of the skill registry or repository when not using the default GitHub repository. For example, 'https://clawhub.ai' for ClawHub-hosted skills."
+    },
+    {
+      "key": "install_path",
+      "description": "The filesystem path where the skill is installed, relative to the scan root. For example, '.agents/skills/weather' or '.claude/skills/lint-fix'."
+    },
+    {
+      "key": "scope",
+      "description": "The installation scope of the skill: 'project' for project-level skills or 'user' for user/global-level skills."
+    },
+    {
+      "key": "client",
+      "description": "The target agent client for client-specific skill paths. For example, 'claude-code', 'cursor', 'windsurf', 'openclaw', 'fast-agent'. Skills in cross-client paths (.agents/skills/) do not require this qualifier."
+    }
+  ],
+  "examples": [
+    "pkg:agentskills/anthropics/xlsx",
+    "pkg:agentskills/anthropics/theme-factory@d211d437",
+    "pkg:agentskills/openclaw-community/weather@1.2.0?repository_url=https://clawhub.ai",
+    "pkg:agentskills/microsoft/mcp-builder?scope=user",
+    "pkg:agentskills/vercel-labs/deploy-to-vercel?scope=project&client=claude-code",
+    "pkg:agentskills/internal/deploy?scope=project&install_path=.agents/skills/deploy",
+    "pkg:agentskills/cross-client/data-pipeline?scope=user"
+  ],
+  "reference_urls": [
+    "https://agentskills.io/specification",
+    "https://agentskills.io/client-implementation/adding-skills-support",
+    "https://github.com/agentskills/agentskills"
+  ]
+}


### PR DESCRIPTION
## Background

  Agent Skills are a standardized, open format for extending AI agent capabilities. A skill is a directory containing a `SKILL.md` file with YAML frontmatter and Markdown instructions. Skills are installed across a growing ecosystem of AI coding agents (Claude Code, GitHub Copilot, Cursor, OpenCode, Windsurf, OpenHands, etc.) and distributed via registries including GitHub, ClawHub, and the Vercel Labs skills CLI.

  There is currently no PURL type to identify these components in SBOMs or software composition analysis. As AI agents are increasingly deployed in development environments and production systems, tracking installed agent skills as inventory is important for security and compliance.

  ## Design decisions

  - **Namespace** (required): The skill publisher or repository owner (e.g., `anthropics`, `microsoft`). The reserved namespace `cross-client` is used when a skill is discovered in the shared`.agents/skills/` path and provenance cannot be determined.
  - **Name** (required): The skill name from the `SKILL.md` frontmatter `name` field.
  - **Version** (optional): A semantic version, git commit SHA, or git tag. Optional because the vast majority of published skills do not include a version field in their frontmatter — version is typically derived from lock files or git metadata.
  - **Qualifiers**: `repository_url` (non-GitHub registries), `scope` (project or user), `client` (target agent), `install_path` (filesystem location).

  ## Examples

  pkg:agentskills/anthropics/xlsx
  pkg:agentskills/anthropics/theme-factory@d211d437
  pkg:agentskills/openclaw-community/weather@1.2.0?repository_url=https://clawhub.ai
  pkg:agentskills/microsoft/mcp-builder?scope=user
  pkg:agentskills/cross-client/data-pipeline?scope=user

  ## Files added/modified

  - `types/agentskills-definition.json` — Type definition
  - `types-doc/agentskills-definition.md` — Documentation
  - `tests/types/agentskills-test.json` — 18 test cases (parse, roundtrip, build)
  - `purl-types-index.json` — Added `agentskills` to the index

  ## References

  - https://agentskills.io/specification
  - https://agentskills.io/client-implementation/adding-skills-support
  - https://github.com/agentskills/agentskills