### PR TITLE
Update case_sensitive properties for golang, npm

### DIFF
--- a/types-doc/golang-definition.md
+++ b/types-doc/golang-definition.md
@@ -21,11 +21,13 @@ The structure of a PURL for this package type is:
 ## Namespace definition
 
 - **Requirement:** Required
+- **Case Sensitive:** Yes
 - **Note:** `The namespace must be lowercased.`
 
 ## Name definition
 
 - **Requirement:** Required
+- **Case Sensitive:** Yes
 - **Note:** `The name must be lowercased.`
 
 ## Version definition

--- a/types-doc/npm-definition.md
+++ b/types-doc/npm-definition.md
@@ -22,12 +22,14 @@ The structure of a PURL for this package type is:
 ## Namespace definition
 
 - **Requirement:** Optional
+- **Case Sensitive:** Yes
 - **Native Label:** scope
 - **Note:** `The namespace is used for the scope of a scoped NPM package. The npm scope @ sign prefix is always percent encoded, as it was in the early days of npm scope.`
 
 ## Name definition
 
 - **Requirement:** Required
+- **Case Sensitive:** Yes
 - **Native Label:** name
 - **Note:** `Per the package.json spec, new package 'must not have uppercase letters in the name', therefore the name must be lowercased. The npm name used to be case sensitive in the early days for some old packages.`
 

--- a/types-doc/npm-definition.md
+++ b/types-doc/npm-definition.md
@@ -31,7 +31,7 @@ The structure of a PURL for this package type is:
 - **Requirement:** Required
 - **Case Sensitive:** Yes
 - **Native Label:** name
-- **Note:** `Per the package.json spec, new package 'must not have uppercase letters in the name', therefore the name must be lowercased. The npm name used to be case sensitive in the early days for some old packages.`
+- **Note:** `The package.json spec changed in 2015 to require that a new package 'must not have uppercase letters in the name', but old packages with mixed case names were "grandfathered in".`
 
 ## Version definition
 

--- a/types/golang-definition.json
+++ b/types/golang-definition.json
@@ -10,12 +10,12 @@
   },
   "namespace_definition": {
     "requirement": "required",
-    "case_sensitive": false,
+    "case_sensitive": true,
     "note": "The namespace must be lowercased."
   },
   "name_definition": {
     "requirement": "required",
-    "case_sensitive": false,
+    "case_sensitive": true,
     "note": "The name must be lowercased."
   },
   "subpath_definition": {

--- a/types/npm-definition.json
+++ b/types/npm-definition.json
@@ -11,13 +11,13 @@
   },
   "namespace_definition": {
     "requirement": "optional",
-    "case_sensitive": false,
+    "case_sensitive": true,
     "native_name": "scope",
     "note": "The namespace is used for the scope of a scoped NPM package. The npm scope @ sign prefix is always percent encoded, as it was in the early days of npm scope."
   },
   "name_definition": {
     "requirement": "required",
-    "case_sensitive": false,
+    "case_sensitive": true,
     "native_name": "name",
     "note": "Per the package.json spec, new package 'must not have uppercase letters in the name', therefore the name must be lowercased. The npm name used to be case sensitive in the early days for some old packages."
   },

--- a/types/npm-definition.json
+++ b/types/npm-definition.json
@@ -19,7 +19,7 @@
     "requirement": "required",
     "case_sensitive": true,
     "native_name": "name",
-    "note": "Per the package.json spec, new package 'must not have uppercase letters in the name', therefore the name must be lowercased. The npm name used to be case sensitive in the early days for some old packages."
+    "note": "The package.json spec changed in 2015 to require that a new package 'must not have uppercase letters in the name', but old packages with mixed case names were \"grandfathered in\"."
   },
   "version_definition": {
     "requirement": "optional",


### PR DESCRIPTION
Changed the respective `case_sensitive` values to `true` in `*-definition.json` files and reran the documentation commands.

Reference: https://github.com/package-url/purl-spec/issues/871