### PR TITLE
Update pkg-iana-registration.txt

### DIFF
--- a/pkg-iana-registration.txt
+++ b/pkg-iana-registration.txt
@@ -2,18 +2,12 @@ Scheme name: pkg
 
 Status: Provisional
 
-Scheme syntax: pkg:<type>/<namespace/name>@version?<qualifiers>#<subpath>
-
-Scheme semantics: Identify and locate a software package.
-
 Applications/protocols that use this scheme name:
-
   Binary Analysis Next Generation (BANG): https://github.com/armijnhemel/binaryanalysis-ng
   CycloneDX: https://github.com/CycloneDX
   Common Security Advisory Framework (CSAF) - ISO/IEC 20153:2025: https://github.com/oasis-tcs/csaf
   DefectDojo: https://github.com/DefectDojo/django-DefectDojo
   DejaCode: https://enterprise.dejacode.com/
-  DeltaCode: https://github.com/nexb/deltacode
   Eclipse Steady: https://github.com/eclipse/steady
   Eclipse Software 360: https://github.com/eclipse/sw360/
   Fasten project: https://github.com/fasten-project
@@ -33,13 +27,14 @@ Applications/protocols that use this scheme name:
   Software Package Data Exchange (SPDX) - ISO/IEC 5962:2021: https://spdx.org/
   Sonatype Nexus Lifecycle: https://www.sonatype.com/products/open-source-security-dependency-management
   VulnerableCode: https://github.com/nexb/vulnerablecode
+The most current list is at: https://packageurl.org/docs/getting-started/toolgrid
 
 Encoding considerations: UTF-8
 
-Contact: Philippe Ombredanne <pombredanne&nexb.com>
+Contact: Philippe Ombredanne <pombredanne&aboutcode.org>
 
-Change controller: nexB Inc. <info&nexb.com>
+Change controller: AboutCode Europe ASBL <info&aboutcode.org)
 
 References:
-  Scheme specification: https://github.com/package-url/purl-spec
-  Scheme implementations: https://github.com/package-url
+  Scheme specification: https://ecma-tc54.github.io/ECMA-427/
+  Scheme implementations: https://packageurl.org/docs/getting-started/toolgrid

--- a/pkg-iana-registration.txt
+++ b/pkg-iana-registration.txt
@@ -29,8 +29,6 @@ Applications/protocols that use this scheme name:
   VulnerableCode: https://github.com/nexb/vulnerablecode
 The most current list is at: https://packageurl.org/docs/getting-started/toolgrid
 
-Encoding considerations: UTF-8
-
 Contact: Philippe Ombredanne <pombredanne&aboutcode.org>
 
 Change controller: AboutCode Europe ASBL <info&aboutcode.org)


### PR DESCRIPTION
Updated to prepare for registration following the template from https://www.rfc-editor.org/info/rfc7595/#section-7.4
- changed Contact and Controller to aboutcode.org
- Removed the scheme syntax and scheme semantics according to latest guidance - these are covered by ECMA-427
- Added URL for more applications/protocols listed on the packageurl.org website
- Updated References / Scheme specification to ECMA-427