### PR TITLE
Add new PURL type: vcpkg

### DIFF
--- a/docs/types/definitions/vcpkg-definition.md
+++ b/docs/types/definitions/vcpkg-definition.md
@@ -1,0 +1,55 @@
+<!--  NOTE: Auto-generated from the JSON PURL type definition.
+Do not manually edit this file. Edit the JSON type definition instead. -->
+
+# PURL Type Definition: vcpkg
+
+- **Type Name:** Vcpkg C/C++ packages
+- **Description:** Packages from the vcpkg C/C++ package manager.
+- **Schema ID:** `https://packageurl.org/types/vcpkg-definition.json`
+
+## PURL Syntax
+
+The structure of a PURL for this package type is:
+
+    pkg:vcpkg/<name>@<version>?<qualifiers>#<subpath>
+
+## Repository Information
+
+- **Use Repository:** Yes
+- **Default Repository URL:** https://github.com/microsoft/vcpkg/
+- **Note:** The absolute URL of the vcpkg registry where the package is available. If omitted, the default registry `https://github.com/microsoft/vcpkg` is assumed. For filesystem registries or [overlay ports](https://learn.microsoft.com/vcpkg/concepts/overlay-ports), the URL uses the `file` scheme.
+
+## Namespace definition
+
+- **Requirement:** Prohibited
+
+## Name definition
+
+- **Requirement:** Required
+- **Native Label:** package-name
+- **Note:** `The vcpkg package name.`
+
+## Version definition
+
+- **Requirement:** Optional
+- **Native Label:** package-version
+- **Note:** `The vcpkg package version.`
+
+## Qualifiers Definition
+
+| Key  | Requirement | Native name | Default Value | Description |
+|------|-------------|-------------|---------------|-------------|
+| port_version | Optional | port_version |  | The vcpkg [port-version](https://learn.microsoft.com/vcpkg/reference/vcpkg-json#port-version). If omitted, the purl refers to port-version 0. |
+| repository_revision | Optional | repository_revision |  | The full 40-character commit hash of the vcpkg registry. For git registries this corresponds to the registry `baseline` field in `vcpkg-configuration.json`. If omitted, the purl refers to the latest revision available. |
+| triplet | Optional | triplet |  | The vcpkg [triplet](https://learn.microsoft.com/vcpkg/concepts/triplets) describing the target build configuration (architecture, operating system, and CRT/library linkage), for example `x64-windows` or `arm64-osx`. It describes the build target and does not affect package identity. |
+
+## Examples
+
+- `pkg:vcpkg/bzip2@1.0.8?port_version=6`
+- `pkg:vcpkg/ffmpeg@5.1.2?repository_url=https:%2F%2Fgithub.com%2Fazure-sdk%2Fvcpkg`
+- `pkg:vcpkg/llvm@15.0.7?repository_url=file:%2F%2F%2FC:%2Flocal-registry%2Fvcpkg`
+- `pkg:vcpkg/bzip2@1.0.8?port_version=6&repository_revision=84a143e4caf6b70db57f28d04c41df4a85c480fa&triplet=x64-linux`
+
+## Note
+
+A purl may carry extra qualifiers that describe the context in which the package is used, such as build configuration or platform. Parsers must tolerate these and may ignore any they do not expect. The `features` qualifier, a comma-separated list of enabled vcpkg feature names, records which optional features were enabled at build time; it is informational and not currently normative.

--- a/purl-types-index.json
+++ b/purl-types-index.json
@@ -36,6 +36,7 @@
   "rpm",
   "swid",
   "swift",
+  "vcpkg",
   "vscode-extension",
   "yocto"
 ]

--- a/tests/types/vcpkg-test.json
+++ b/tests/types/vcpkg-test.json
@@ -1,0 +1,251 @@
+{
+  "$schema": "https://packageurl.org/schemas/purl-test.schema-0.1.json",
+  "tests": [
+    {
+      "description": "simple vcpkg purl",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:vcpkg/bzip2@1.0.8",
+      "expected_output": {
+        "type": "vcpkg",
+        "namespace": null,
+        "name": "bzip2",
+        "version": "1.0.8",
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "vcpkg with port_version",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:vcpkg/bzip2@1.0.8?port_version=6",
+      "expected_output": {
+        "type": "vcpkg",
+        "namespace": null,
+        "name": "bzip2",
+        "version": "1.0.8",
+        "qualifiers": {
+          "port_version": "6"
+        },
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "vcpkg non-default git registry",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:vcpkg/ffmpeg@5.1.2?repository_url=https:%2F%2Fgithub.com%2Fazure-sdk%2Fvcpkg&port_version=3",
+      "expected_output": {
+        "type": "vcpkg",
+        "namespace": null,
+        "name": "ffmpeg",
+        "version": "5.1.2",
+        "qualifiers": {
+          "repository_url": "https://github.com/azure-sdk/vcpkg",
+          "port_version": "3"
+        },
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "vcpkg filesystem registry or overlay port",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:vcpkg/llvm@15.0.7?repository_url=file:%2F%2F%2FC:%2Flocal-registry%2Fvcpkg&port_version=3",
+      "expected_output": {
+        "type": "vcpkg",
+        "namespace": null,
+        "name": "llvm",
+        "version": "15.0.7",
+        "qualifiers": {
+          "repository_url": "file:///C:/local-registry/vcpkg",
+          "port_version": "3"
+        },
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "vcpkg with additional qualifiers",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:vcpkg/bzip2@1.0.8?port_version=6&repository_revision=84a143e4caf6b70db57f28d04c41df4a85c480fa&triplet=x64-linux",
+      "expected_output": {
+        "type": "vcpkg",
+        "namespace": null,
+        "name": "bzip2",
+        "version": "1.0.8",
+        "qualifiers": {
+          "port_version": "6",
+          "repository_revision": "84a143e4caf6b70db57f28d04c41df4a85c480fa",
+          "triplet": "x64-linux"
+        },
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "vcpkg namespace is prohibited; boost-asio is a single port name, not a namespace and name",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:vcpkg/boost/asio@1.84.0",
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "Should fail to parse a vcpkg purl with a namespace because vcpkg namespaces are prohibited"
+    },
+    {
+      "description": "vcpkg purl without a name",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:vcpkg/@1.0.8",
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "Should fail to parse a vcpkg purl without a name because the name is required"
+    },
+    {
+      "description": "vcpkg purl with only the type and no name",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:vcpkg",
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "Should fail to parse a vcpkg purl without a name because the name is required"
+    },
+    {
+      "description": "vcpkg build with a prohibited namespace",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "vcpkg",
+        "namespace": "boost",
+        "name": "asio",
+        "version": "1.84.0",
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "Should fail to build a vcpkg purl with a namespace because vcpkg namespaces are prohibited"
+    },
+    {
+      "description": "vcpkg build without a name",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "vcpkg",
+        "namespace": null,
+        "name": null,
+        "version": "1.0.8",
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "Should fail to build a vcpkg purl without a name because the name is required"
+    },
+    {
+      "description": "a trailing #6 is parsed as a subpath, not a port-version, which is why port_version is a qualifier",
+      "test_group": "advanced",
+      "test_type": "parse",
+      "input": "pkg:vcpkg/zlib@1.3.1#6",
+      "expected_output": {
+        "type": "vcpkg",
+        "namespace": null,
+        "name": "zlib",
+        "version": "1.3.1",
+        "qualifiers": null,
+        "subpath": "6"
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "vcpkg purl with a features qualifier listing enabled features",
+      "test_group": "advanced",
+      "test_type": "parse",
+      "input": "pkg:vcpkg/curl@8.6.0?features=ssl%2Chttp2",
+      "expected_output": {
+        "type": "vcpkg",
+        "namespace": null,
+        "name": "curl",
+        "version": "8.6.0",
+        "qualifiers": {
+          "features": "ssl,http2"
+        },
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "vcpkg purl with a static-linkage triplet",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:vcpkg/zlib@1.3.1?triplet=x64-windows-static",
+      "expected_output": {
+        "type": "vcpkg",
+        "namespace": null,
+        "name": "zlib",
+        "version": "1.3.1",
+        "qualifiers": {
+          "triplet": "x64-windows-static"
+        },
+        "subpath": null
+      },
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "roundtrip a canonical vcpkg purl with a port_version",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:vcpkg/bzip2@1.0.8?port_version=6",
+      "expected_output": "pkg:vcpkg/bzip2@1.0.8?port_version=6",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "build a vcpkg purl with a port_version",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "vcpkg",
+        "namespace": null,
+        "name": "bzip2",
+        "version": "1.0.8",
+        "qualifiers": {
+          "port_version": "6"
+        },
+        "subpath": null
+      },
+      "expected_output": "pkg:vcpkg/bzip2@1.0.8?port_version=6",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "build a vcpkg purl without a port_version omits the qualifier",
+      "test_group": "base",
+      "test_type": "build",
+      "input": {
+        "type": "vcpkg",
+        "namespace": null,
+        "name": "bzip2",
+        "version": "1.0.8",
+        "qualifiers": null,
+        "subpath": null
+      },
+      "expected_output": "pkg:vcpkg/bzip2@1.0.8",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    }
+  ]
+}

--- a/types/vcpkg-definition.json
+++ b/types/vcpkg-definition.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
+  "$id": "https://packageurl.org/types/vcpkg-definition.json",
+  "type": "vcpkg",
+  "type_name": "Vcpkg C/C++ packages",
+  "description": "Packages from the vcpkg C/C++ package manager.",
+  "repository": {
+    "use_repository": true,
+    "default_repository_url": "https://github.com/microsoft/vcpkg/",
+    "note": "The absolute URL of the vcpkg registry where the package is available. If omitted, the default registry `https://github.com/microsoft/vcpkg` is assumed. For filesystem registries or [overlay ports](https://learn.microsoft.com/vcpkg/concepts/overlay-ports), the URL uses the `file` scheme."
+  },
+  "namespace_definition": {
+    "requirement": "prohibited"
+  },
+  "name_definition": {
+    "requirement": "required",
+    "native_name": "package-name",
+    "note": "The vcpkg package name."
+  },
+  "version_definition": {
+    "requirement": "optional",
+    "native_name": "package-version",
+    "note": "The vcpkg package version."
+  },
+  "qualifiers_definition": [
+    {
+      "key": "port_version",
+      "native_name": "port_version",
+      "requirement": "optional",
+      "description": "The vcpkg [port-version](https://learn.microsoft.com/vcpkg/reference/vcpkg-json#port-version). If omitted, the purl refers to port-version 0."
+    },
+    {
+      "key": "repository_revision",
+      "native_name": "repository_revision",
+      "requirement": "optional",
+      "description": "The full 40-character commit hash of the vcpkg registry. For git registries this corresponds to the registry `baseline` field in `vcpkg-configuration.json`. If omitted, the purl refers to the latest revision available."
+    },
+    {
+      "key": "triplet",
+      "native_name": "triplet",
+      "requirement": "optional",
+      "description": "The vcpkg [triplet](https://learn.microsoft.com/vcpkg/concepts/triplets) describing the target build configuration (architecture, operating system, and CRT/library linkage), for example `x64-windows` or `arm64-osx`. It describes the build target and does not affect package identity."
+    }
+  ],
+  "note": "A purl may carry extra qualifiers that describe the context in which the package is used, such as build configuration or platform. Parsers must tolerate these and may ignore any they do not expect. The `features` qualifier, a comma-separated list of enabled vcpkg feature names, records which optional features were enabled at build time; it is informational and not currently normative.",
+  "examples": [
+    "pkg:vcpkg/bzip2@1.0.8?port_version=6",
+    "pkg:vcpkg/ffmpeg@5.1.2?repository_url=https:%2F%2Fgithub.com%2Fazure-sdk%2Fvcpkg",
+    "pkg:vcpkg/llvm@15.0.7?repository_url=file:%2F%2F%2FC:%2Flocal-registry%2Fvcpkg",
+    "pkg:vcpkg/bzip2@1.0.8?port_version=6&repository_revision=84a143e4caf6b70db57f28d04c41df4a85c480fa&triplet=x64-linux"
+  ]
+}


### PR DESCRIPTION
Registers a `vcpkg` PURL type for Microsoft's C/C++ package manager. Continues #562 (and #245); closes #217.

## Adds
- `types/vcpkg-definition.json`: type definition
- `tests/types/vcpkg-test.json`: parse tests
- `types-doc/vcpkg-definition.md`: generated docs
- `vcpkg` in `purl-types-index.json`

## Shape
`pkg:vcpkg/<name>@<version>?<qualifiers>`

- namespace: prohibited (vcpkg has no namespace; prefixes like `boost-` are part of the name)
- name: required, the port name
- version: optional, the upstream version
- qualifiers: `port_version` (port-version, default 0), `repository_revision` (registry baseline SHA), `triplet` (target config), `repository_url` (non-default registry)

## Design notes
- `port_version` is a qualifier, not part of the version: `#` is the PURL subpath delimiter and vcpkg's `version-string` scheme disallows it. Matches what `microsoft/component-detection` emits, e.g. `pkg:vcpkg/nlohmann-json@3.10.4?port_version=5`. Resolves @pombredanne's question on #562.
- `triplet` is one optional qualifier (e.g. `x64-windows-static`), not separate os/arch/linkage keys. It's build/target context and doesn't affect package identity.
- `repository_revision` is the 40-char registry commit SHA (the `baseline` in `vcpkg-configuration.json`).

`make check` passes; docs regenerated with `make gendocs`. Related: https://github.com/microsoft/vcpkg/issues/44201.
