### PR TITLE
Fix rpm example

### DIFF
--- a/types/rpm-definition.json
+++ b/types/rpm-definition.json
@@ -38,6 +38,6 @@
   ],
   "examples": [
     "pkg:rpm/fedora/curl@7.50.3-1.fc25?arch=i386&distro=fedora-25",
-    "pkg:rpm/centerim@4.22.10-1.el6?arch=i686&epoch=1&distro=fedora-25"
+    "pkg:rpm/fedora/centerim@4.22.10-1.el6?arch=i686&epoch=1&distro=fedora-25"
   ]
 }


### PR DESCRIPTION
Added namespace (required component) to rpm example. Addresses 2 issues:
- #892
- #896