### PR TITLE
Create purl-type-notes-template.md

### DIFF
--- a/docs/types/notes/purl-type-notes-template.md
+++ b/docs/types/notes/purl-type-notes-template.md
@@ -1,0 +1,25 @@
+
+# Notes for PURL type: {'purl-type'}
+(The following topics are suggestions - they are not required.)
+
+## PURL type history
+
+### Original registration
+{Describe the reason for the original registration of this PURL **type**. 
+This will often including summarizing commentary from the issue/PR to
+spare the reader from trying to follow those threads. You may want to include 
+links to relevant discussions, issues or PRs.}
+
+## Definition notes
+{Provide additional information about the PURL **type** definition that is 
+more detailed than the notes in the JSON format **type** definition file. This
+information will often be at the PURL component level.}
+
+### Changes
+{Provide a list of major changes to the definition of this PURL **type**.  You
+ may want to include links to relevant issues or discussions.}
+
+## Usage notes
+{Describe how and where this PURL **type** is typically used.}
+
+## More Information


### PR DESCRIPTION
- Added draft template for PURL **type** definition notes 
- Also needed to instantiate the the `docs/types/notes/` folder in the repo