### PR TITLE
conan: Sort example qualifiers

### DIFF
--- a/types/conan-definition.json
+++ b/types/conan-definition.json
@@ -52,7 +52,7 @@
   "note": "Additional qualifiers can be used to distinguish Conan packages with different settings or options, e.g. os=Linux, build_type=Debug or shared=True. If no additional qualifiers are used to distinguish Conan packages build with different settings or options, then the purl is ambiguous and it is up to the user to work out which package is being referred to (e.g. with context information).",
   "examples": [
     "pkg:conan/openssl@3.0.3",
-    "pkg:conan/openssl.org/openssl@3.0.3?user=bincrafters&channel=stable",
-    "pkg:conan/openssl.org/openssl@3.0.3?arch=x86_64&build_type=Debug&compiler=Visual%20Studio&compiler.runtime=MDd&compiler.version=16&os=Windows&shared=True&rrev=93a82349c31917d2d674d22065c7a9ef9f380c8e&prev=b429db8a0e324114c25ec387bfd8281f330d7c5c"
+    "pkg:conan/openssl.org/openssl@3.0.3?channel=stable&user=bincrafters",
+    "pkg:conan/openssl.org/openssl@3.0.3?arch=x86_64&build_type=Debug&compiler=Visual%20Studio&compiler.runtime=MDd&compiler.version=16&os=Windows&prev=b429db8a0e324114c25ec387bfd8281f330d7c5c&rrev=93a82349c31917d2d674d22065c7a9ef9f380c8e&shared=True"
   ]
 }


### PR DESCRIPTION
This PR resolves the issue reported by the new tests for URI-PackageURL regarding Conan qualifiers.

```
$ PURL_TYPE=conan PURL_EXAMPLES_TESTING=1 prove -lv t/99-purl-type-definition.t 
t/99-purl-type-definition.t .. 
ok 1 - require URI::PackageURL;
ok 2 - require URI::PackageURL::Type;
ok 3 - require URI::PackageURL::Util;
# Test only conan testcases
# Subtest: conan - component requirement
    ok 1 - 'name' component requirement --> required
    ok 2 - 'namespace' component requirement --> optional
    ok 3 - 'version' component requirement --> optional
    # (!) No 'subpath' component in definition
    ok 4 - 'qualifiers' component requirement --> optional
    1..4
ok 4 - conan - component requirement
# Subtest: conan - examples
    ok 1 - Test example \#1
    not ok 2 - Test example \#2

    #   Failed test 'Test example #2'
    #   at t/99-purl-type-definition.t line 56.
    #          got: 'pkg:conan/openssl.org/openssl@3.0.3?channel=stable&user=bincrafters'
    #     expected: 'pkg:conan/openssl.org/openssl@3.0.3?user=bincrafters&channel=stable'
    not ok 3 - Test example \#3

    #   Failed test 'Test example #3'
    #   at t/99-purl-type-definition.t line 56.
    #          got: 'pkg:conan/openssl.org/openssl@3.0.3?arch=x86_64&build_type=Debug&compiler=Visual%20Studio&compiler.runtime=MDd&compiler.version=16&os=Windows&prev=b429db8a0e324114c25ec387bfd8281f330d7c5c&rrev=93a82349c31917d2d674d22065c7a9ef9f380c8e&shared=True'
    #     expected: 'pkg:conan/openssl.org/openssl@3.0.3?arch=x86_64&build_type=Debug&compiler=Visual%20Studio&compiler.runtime=MDd&compiler.version=16&os=Windows&shared=True&rrev=93a82349c31917d2d674d22065c7a9ef9f380c8e&prev=b429db8a0e324114c25ec387bfd8281f330d7c5c'
    1..3
    # Looks like you failed 2 tests of 3.
not ok 5 - conan - examples

#   Failed test 'conan - examples'
#   at t/99-purl-type-definition.t line 61.
1..5
# Looks like you failed 1 test of 5.
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/5 subtests 

Test Summary Report
-------------------
t/99-purl-type-definition.t (Wstat: 256 (exited 1) Tests: 5 Failed: 1)
  Failed test:  5
  Non-zero exit status: 1
Files=1, Tests=5,  0 wallclock secs ( 0.03 usr  0.01 sys +  0.12 cusr  0.01 csys =  0.17 CPU)
Result: FAIL
```