### PR TITLE
vscode-extension: Fix unencoded slashes in URL in Example

### DIFF
--- a/types/vscode-extension-definition.json
+++ b/types/vscode-extension-definition.json
@@ -37,7 +37,7 @@
   ],
   "examples": [
     "pkg:vscode-extension/ms-python/python@2023.25.10292213",
-    "pkg:vscode-extension/muhammad-sammy/csharp@2.15.30?repository_url=https://open-vsx.org",
+    "pkg:vscode-extension/muhammad-sammy/csharp@2.15.30?repository_url=https:%2F%2Fopen-vsx.org",
     "pkg:vscode-extension/golang/go@0.39.1?platform=win32-x64"
   ],
   "reference_urls": [


### PR DESCRIPTION
This PR resolves the issue reported by the new tests for URI-PackageURL regarding vscode-extension (unencoded slashes in examples).

```
$ PURL_TYPE=vscode-extension PURL_EXAMPLES_TESTING=1 prove -lv t/99-purl-type-definition.t 
t/99-purl-type-definition.t .. 
ok 1 - require URI::PackageURL;
ok 2 - require URI::PackageURL::Type;
ok 3 - require URI::PackageURL::Util;
# Test only vscode-extension testcases
# Subtest: vscode-extension - component requirement
    ok 1 - 'name' component requirement --> required
    ok 2 - 'namespace' component requirement --> required
    ok 3 - 'version' component requirement --> optional
    # (!) No 'subpath' component in definition
    ok 4 - 'qualifiers' component requirement --> optional
    1..4
ok 4 - vscode-extension - component requirement
# Subtest: vscode-extension - examples
    ok 1 - Test example \#1
    not ok 2 - Test example \#2

    #   Failed test 'Test example #2'
    #   at t/99-purl-type-definition.t line 56.
    #          got: 'pkg:vscode-extension/muhammad-sammy/csharp@2.15.30?repository_url=https:%2F%2Fopen-vsx.org'
    #     expected: 'pkg:vscode-extension/muhammad-sammy/csharp@2.15.30?repository_url=https://open-vsx.org'
    ok 3 - Test example \#3
    1..3
    # Looks like you failed 1 test of 3.
not ok 5 - vscode-extension - examples

#   Failed test 'vscode-extension - examples'
#   at t/99-purl-type-definition.t line 61.
1..5
# Looks like you failed 1 test of 5.
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/5 subtests 

Test Summary Report
-------------------
t/99-purl-type-definition.t (Wstat: 256 (exited 1) Tests: 5 Failed: 1)
  Failed test:  5
  Non-zero exit status: 1
Files=1, Tests=5,  1 wallclock secs ( 0.15 usr  0.02 sys +  0.57 cusr  0.04 csys =  0.78 CPU)
Result: FAIL
```