### PR TITLE
Add new PURL type: 'firefox-extension'

### DIFF
--- a/docs/types/definitions/firefox-extension-definition.md
+++ b/docs/types/definitions/firefox-extension-definition.md
@@ -1,0 +1,53 @@
+<!--  NOTE: Auto-generated from the JSON PURL type definition.
+Do not manually edit this file. Edit the JSON type definition instead. -->
+
+# PURL Type Definition: firefox-extension
+
+- **Type Name:** Firefox Browser Extensions (Add-ons)
+- **Description:** Firefox Browser Extensions (add-ons), typically distributed through addons.mozilla.org (AMO). AMO exposes a documented public API where add-ons can be looked up by extension ID, and where previous versions of an add-on are listed and remain downloadable. See https://mozilla.github.io/addons-server/topics/api/addons.html
+- **Schema ID:** `https://packageurl.org/types/firefox-extension-definition.json`
+
+## PURL Syntax
+
+The structure of a PURL for this package type is:
+
+    pkg:firefox-extension/<name>@<version>?<qualifiers>#<subpath>
+
+## Repository Information
+
+- **Use Repository:** Yes
+- **Default Repository URL:** https://addons.mozilla.org
+- **Note:** An add-on can be queried at https://addons.mozilla.org/api/v5/addons/addon/<extension-id>/ and its versions at https://addons.mozilla.org/api/v5/addons/addon/<extension-id>/versions/. Extensions may also be signed by Mozilla and self-distributed outside of AMO, in which case there is no repository.
+
+## Namespace definition
+
+- **Requirement:** Prohibited
+- **Note:** `There is no namespace`
+
+## Name definition
+
+- **Requirement:** Required
+- **Permitted Characters:** `^([a-zA-Z0-9-._]*@[a-zA-Z0-9-._]+|\{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\})$`
+- **Case Sensitive:** Yes
+- **Native Label:** extension_id
+- **Note:** `The name is the extension ID set in the 'browser_specific_settings.gecko.id' key of manifest.json: either an email-like string of 80 characters or less (e.g. 'uBlock0@raymondhill.net') or a GUID enclosed in curly braces (e.g. '{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}'). This is the stable unique identifier of an add-on; it is not the same as the human-readable display name, nor the mutable AMO listing slug used in store page URLs. Because '@', '{' and '}' are not allowed as-is in a PURL name, they must be percent-encoded as %40, %7B and %7D in the PURL string. See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings`
+
+## Version definition
+
+- **Requirement:** Optional
+- **Permitted Characters:** `^\d+(\.\d+){0,3}$`
+- **Native Label:** version
+- **Note:** `The version is semver-like with 1 to 4 dot-separated numbers, as set in the 'version' key of manifest.json. addons.mozilla.org enforces this format for new submissions; a few older add-on versions predating this rule may not conform. When the version is omitted, the PURL references the latest version. See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version`
+
+## Examples
+
+- `pkg:firefox-extension/uBlock0%40raymondhill.net@1.72.2`
+- `pkg:firefox-extension/%40testpilot-containers@8.3.8`
+- `pkg:firefox-extension/%7Bd10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d%7D@4.41.1`
+- `pkg:firefox-extension/uBlock0%40raymondhill.net`
+
+## Reference URLs
+
+- `https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings`
+- `https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version`
+- `https://mozilla.github.io/addons-server/topics/api/addons.html`

--- a/purl-types-index.json
+++ b/purl-types-index.json
@@ -15,6 +15,7 @@
   "cran",
   "deb",
   "docker",
+  "firefox-extension",
   "gem",
   "generic",
   "github",

--- a/tests/types/firefox-extension-test.json
+++ b/tests/types/firefox-extension-test.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://packageurl.org/schemas/purl-test.schema-1.0.json",
+  "tests": [
+    {
+      "description": "valid firefox purl (name: email-like extension ID)",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:firefox-extension/uBlock0%40raymondhill.net@1.72.2",
+      "expected_output": "pkg:firefox-extension/uBlock0%40raymondhill.net@1.72.2",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "valid firefox purl (name: email-like extension ID with empty local part)",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:firefox-extension/%40testpilot-containers@8.3.8",
+      "expected_output": "pkg:firefox-extension/%40testpilot-containers@8.3.8",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "valid firefox purl (name: GUID extension ID)",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:firefox-extension/%7Bd10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d%7D@4.41.1",
+      "expected_output": "pkg:firefox-extension/%7Bd10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d%7D@4.41.1",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "valid firefox purl (version: missing)",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:firefox-extension/uBlock0%40raymondhill.net",
+      "expected_output": "pkg:firefox-extension/uBlock0%40raymondhill.net",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "invalid firefox purl (name: AMO listing slug instead of extension ID)",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:firefox-extension/ublock-origin@1.72.2",
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "permitted_characters"
+    },
+    {
+      "description": "invalid firefox purl (name: malformed GUID)",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:firefox-extension/%7Bd10d0bf8-f5b5%7D@4.41.1",
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "permitted_characters"
+    },
+    {
+      "description": "invalid firefox purl (version: too many segments)",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:firefox-extension/uBlock0%40raymondhill.net@1.2.3.4.5",
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "permitted_characters"
+    },
+    {
+      "description": "invalid firefox purl (version: invalid characters)",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:firefox-extension/uBlock0%40raymondhill.net@1.2.3-beta",
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "permitted_characters"
+    }
+  ]
+}

--- a/types/firefox-extension-definition.json
+++ b/types/firefox-extension-definition.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
+  "$id": "https://packageurl.org/types/firefox-extension-definition.json",
+  "type": "firefox-extension",
+  "type_name": "Firefox Browser Extensions (Add-ons)",
+  "description": "Firefox Browser Extensions (add-ons), typically distributed through addons.mozilla.org (AMO). AMO exposes a documented public API where add-ons can be looked up by extension ID, and where previous versions of an add-on are listed and remain downloadable. See https://mozilla.github.io/addons-server/topics/api/addons.html",
+  "repository": {
+    "use_repository": true,
+    "default_repository_url": "https://addons.mozilla.org",
+    "note": "An add-on can be queried at https://addons.mozilla.org/api/v5/addons/addon/<extension-id>/ and its versions at https://addons.mozilla.org/api/v5/addons/addon/<extension-id>/versions/. Extensions may also be signed by Mozilla and self-distributed outside of AMO, in which case there is no repository."
+  },
+  "namespace_definition": {
+    "requirement": "prohibited",
+    "note": "There is no namespace"
+  },
+  "name_definition": {
+    "native_name": "extension_id",
+    "requirement": "required",
+    "permitted_characters": "^([a-zA-Z0-9-._]*@[a-zA-Z0-9-._]+|\\{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\})$",
+    "case_sensitive": true,
+    "note": "The name is the extension ID set in the 'browser_specific_settings.gecko.id' key of manifest.json: either an email-like string of 80 characters or less (e.g. 'uBlock0@raymondhill.net') or a GUID enclosed in curly braces (e.g. '{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}'). This is the stable unique identifier of an add-on; it is not the same as the human-readable display name, nor the mutable AMO listing slug used in store page URLs. Because '@', '{' and '}' are not allowed as-is in a PURL name, they must be percent-encoded as %40, %7B and %7D in the PURL string. See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings"
+  },
+  "version_definition": {
+    "native_name": "version",
+    "requirement": "optional",
+    "permitted_characters": "^\\d+(\\.\\d+){0,3}$",
+    "note": "The version is semver-like with 1 to 4 dot-separated numbers, as set in the 'version' key of manifest.json. addons.mozilla.org enforces this format for new submissions; a few older add-on versions predating this rule may not conform. When the version is omitted, the PURL references the latest version. See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version"
+  },
+  "examples": [
+    "pkg:firefox-extension/uBlock0%40raymondhill.net@1.72.2",
+    "pkg:firefox-extension/%40testpilot-containers@8.3.8",
+    "pkg:firefox-extension/%7Bd10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d%7D@4.41.1",
+    "pkg:firefox-extension/uBlock0%40raymondhill.net"
+  ],
+  "reference_urls": [
+    "https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings",
+    "https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version",
+    "https://mozilla.github.io/addons-server/topics/api/addons.html"
+  ]
+}


### PR DESCRIPTION
This PR registers a new PURL **type** for Firefox Browser Extensions (add-ons), as distributed via [addons.mozilla.org](https://addons.mozilla.org) (AMO). It follows the structure and review feedback of the recently merged `chrome-extension` type (#522), and answers the questions from the [Register new PURL type](https://github.com/package-url/purl-spec/blob/main/.github/ISSUE_TEMPLATE/Register%20new%20PURL%20type.md) template below.

- [x] Why is this new PURL **type** needed?
- [x] What are the PURL component level definitions?
- [x] What input do you have from the relevant package ecosystem/community?
- [x] Are there any open questions or concerns about this new PURL **type**?

## Why is this new PURL type needed?

Browser extensions are installable, versioned software packages and an increasingly important software supply chain surface (SBOMs, malware and vulnerability advisories, policy/inventory tooling all need to reference them). The `chrome-extension` type was registered in #522; Firefox is the other major independent extension ecosystem, with its own store (AMO), its own extension ID format, and — unlike Chrome — a documented public API with downloadable version history. There is currently no standard way to identify a Firefox add-on and version.

## What are the PURL component level definitions?

Full definition in [`types/firefox-extension-definition.json`](https://github.com/annextuckner/purl-spec/blob/add-firefox-extension-type/types/firefox-extension-definition.json), with generated docs and test cases included in this PR.

| Component | Definition |
|---|---|
| `type` | `firefox-extension` (descriptive `<browser>-extension` naming per #522 / #673 feedback) |
| `namespace` | Prohibited — there is no namespace |
| `name` | **Required.** The extension ID from the `browser_specific_settings.gecko.id` manifest key: either an email-like string of 80 chars or less (e.g. `uBlock0@raymondhill.net`) or a GUID in curly braces (e.g. `{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}`). Case sensitive. `permitted_characters`: `^([a-zA-Z0-9-._]*@[a-zA-Z0-9-._]+|\{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\})$`. `@`, `{`, `}` are percent-encoded as `%40`, `%7B`, `%7D` in the PURL string. |
| `version` | **Optional** (omitted = latest). 1–4 dot-separated numbers per the [WebExtension manifest `version` key](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version), enforced by AMO for new submissions. `permitted_characters`: `^\d+(\.\d+){0,3}$` |
| `qualifiers` / `subpath` | None defined |
| repository | `https://addons.mozilla.org` — add-ons are queryable by extension ID via the [documented AMO API](https://mozilla.github.io/addons-server/topics/api/addons.html), and previous versions are listed and downloadable. |

Example PURLs (all real, verified against the AMO v5 API):

- `pkg:firefox-extension/uBlock0%40raymondhill.net@1.72.2`
- `pkg:firefox-extension/%40testpilot-containers@8.3.8`
- `pkg:firefox-extension/%7Bd10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d%7D@4.41.1`
- `pkg:firefox-extension/uBlock0%40raymondhill.net` (latest)

## What input do you have from the relevant package ecosystem/community?

- In #522, @patrickkettner (Chrome extensions team) reviewed the browser-extension PURL approach and noted the "mozilla add-on store would share identical logic to what you created" — i.e. stable store extension ID as name, optional 1–4 segment version.
- The name and version formats here are taken directly from Mozilla's official documentation ([`browser_specific_settings.gecko.id`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings), [manifest `version`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version)) and the [AMO addons-server API docs](https://mozilla.github.io/addons-server/topics/api/addons.html); the extension ID is the key Mozilla itself uses in its API and blocklist.
- No direct review from Mozilla staff yet — happy to seek input from the AMO/add-ons team if maintainers want vendor sign-off as was done for #522.

## Are there any open questions or concerns about this new PURL type?

- **Extension ID vs. AMO slug as the name.** The mutable, AMO-only listing slug (e.g. `ublock-origin`) was deliberately rejected in favor of the immutable extension ID, consistent with the #522 feedback favoring collision-free primary keys — and because Firefox also supports signed self-distributed extensions that have no AMO listing or slug. The trade-off is percent-encoding (`%40`, `%7B`, `%7D`) in every PURL. An expected-failure test guards against slugs being used as names.
- **Case sensitivity**: extension IDs preserve case (`uBlock0@raymondhill.net`), so the name is defined as case sensitive to avoid mangling the canonical ID; AMO lookups are tolerant in practice.
- **Legacy versions**: a small number of pre-2022 add-on versions use the older "toolkit" version format (letters, e.g. `1.0b3`) and would not match the version pattern; the definition notes this and follows the format AMO enforces today.

## Checks

Docs and `purl-types-index.json` regenerated with `make gendocs`; `make checkjson` passes; roundtrip canonicalization of all valid test cases verified with packageurl-python.

A sibling PR (#928) adds `edge-extension` for the Microsoft Edge Add-ons store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)