### PR TITLE
Add new PURL type: 'edge-extension'

### DIFF
--- a/docs/types/definitions/edge-extension-definition.md
+++ b/docs/types/definitions/edge-extension-definition.md
@@ -1,0 +1,52 @@
+<!--  NOTE: Auto-generated from the JSON PURL type definition.
+Do not manually edit this file. Edit the JSON type definition instead. -->
+
+# PURL Type Definition: edge-extension
+
+- **Type Name:** Microsoft Edge Browser Extensions (Add-ons)
+- **Description:** Microsoft Edge Browser Extensions (Add-ons), distributed through the Microsoft Edge Add-ons store. Edge extensions use the same CRX packaging and 32-character extension ID format as Chrome extensions. There is no officially documented store API; two known data sources are a product details endpoint at https://microsoftedge.microsoft.com/addons/getproductdetailsbycrxid/<extension-id> and an 'updatecheck' style endpoint at https://edge.microsoft.com/extensionwebstorebase/v1/crx which follows the same protocol as the Chrome Web Store, see https://github.com/chromium/chromium/blob/main/docs/updater/protocol_3_1.md
+- **Schema ID:** `https://packageurl.org/types/edge-extension-definition.json`
+
+## PURL Syntax
+
+The structure of a PURL for this package type is:
+
+    pkg:edge-extension/<name>@<version>?<qualifiers>#<subpath>
+
+## Repository Information
+
+- **Use Repository:** Yes
+- **Default Repository URL:** https://microsoftedge.microsoft.com/addons
+- **Note:** Store pages are at https://microsoftedge.microsoft.com/addons/detail/<slug>/<extension-id>. There is no officially documented API, and only the latest version of an extension is publicly available.
+
+## Namespace definition
+
+- **Requirement:** Prohibited
+- **Note:** `There is no namespace`
+
+## Name definition
+
+- **Requirement:** Required
+- **Permitted Characters:** `^[a-p]{32}$`
+- **Native Label:** extension_id
+- **Note:** `The name is the extension ID: 32 characters in the range a-p (base16-encoded with letters instead of hex digits), the same format as Chrome extension IDs, and is case insensitive. This is not the same as the display name, which is human readable and may vary with locale. The extension ID is the last path segment of the store page URL.`
+
+## Version definition
+
+- **Requirement:** Optional
+- **Permitted Characters:** `^\d+(\.\d+){0,3}$`
+- **Native Label:** version
+- **Note:** `The edge extension version is semver-like but 1-4 segments, following the same manifest version format as Chrome extensions. When the version is omitted, the PURL references the latest version. See https://developer.chrome.com/docs/extensions/reference/manifest/version`
+
+## Examples
+
+- `pkg:edge-extension/odfafepnkmbhccpbejgmiehpchacaeak@1.72.2`
+- `pkg:edge-extension/cimighlppcgcoapaliogpjjdehbnofhn@2026.714.1952`
+- `pkg:edge-extension/nffknjpglkklphnibdiadeeeeailfnog@25.5.0`
+- `pkg:edge-extension/odfafepnkmbhccpbejgmiehpchacaeak`
+
+## Reference URLs
+
+- `https://learn.microsoft.com/en-us/microsoft-edge/extensions/`
+- `https://developer.chrome.com/docs/extensions/reference/manifest/version`
+- `https://github.com/chromium/chromium/blob/main/docs/updater/protocol_3_1.md`

--- a/purl-types-index.json
+++ b/purl-types-index.json
@@ -15,6 +15,7 @@
   "cran",
   "deb",
   "docker",
+  "edge-extension",
   "gem",
   "generic",
   "github",

--- a/tests/types/edge-extension-test.json
+++ b/tests/types/edge-extension-test.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://packageurl.org/schemas/purl-test.schema-1.0.json",
+  "tests": [
+    {
+      "description": "valid edge purl (version: full)",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:edge-extension/cimighlppcgcoapaliogpjjdehbnofhn@2026.714.1952",
+      "expected_output": "pkg:edge-extension/cimighlppcgcoapaliogpjjdehbnofhn@2026.714.1952",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "valid edge purl (version: short)",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:edge-extension/nffknjpglkklphnibdiadeeeeailfnog@25.5.0",
+      "expected_output": "pkg:edge-extension/nffknjpglkklphnibdiadeeeeailfnog@25.5.0",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "valid edge purl (version: missing)",
+      "test_group": "base",
+      "test_type": "roundtrip",
+      "input": "pkg:edge-extension/odfafepnkmbhccpbejgmiehpchacaeak",
+      "expected_output": "pkg:edge-extension/odfafepnkmbhccpbejgmiehpchacaeak",
+      "expected_failure": false,
+      "expected_failure_reason": null
+    },
+    {
+      "description": "invalid edge purl (name: invalid characters)",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:edge-extension/44444epnkmbhccpbejgmiehpchacaeak",
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "permitted_characters"
+    },
+    {
+      "description": "invalid edge purl (name: wrong length)",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:edge-extension/dogs",
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "permitted_characters"
+    },
+    {
+      "description": "invalid edge purl (version: too many segments)",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:edge-extension/odfafepnkmbhccpbejgmiehpchacaeak@1.2.3.4.5",
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "permitted_characters"
+    },
+    {
+      "description": "invalid edge purl (version: invalid characters)",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "pkg:edge-extension/odfafepnkmbhccpbejgmiehpchacaeak@1.2.3-beta",
+      "expected_output": null,
+      "expected_failure": true,
+      "expected_failure_reason": "permitted_characters"
+    }
+  ]
+}

--- a/types/edge-extension-definition.json
+++ b/types/edge-extension-definition.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
+  "$id": "https://packageurl.org/types/edge-extension-definition.json",
+  "type": "edge-extension",
+  "type_name": "Microsoft Edge Browser Extensions (Add-ons)",
+  "description": "Microsoft Edge Browser Extensions (Add-ons), distributed through the Microsoft Edge Add-ons store. Edge extensions use the same CRX packaging and 32-character extension ID format as Chrome extensions. There is no officially documented store API; two known data sources are a product details endpoint at https://microsoftedge.microsoft.com/addons/getproductdetailsbycrxid/<extension-id> and an 'updatecheck' style endpoint at https://edge.microsoft.com/extensionwebstorebase/v1/crx which follows the same protocol as the Chrome Web Store, see https://github.com/chromium/chromium/blob/main/docs/updater/protocol_3_1.md",
+  "repository": {
+    "use_repository": true,
+    "default_repository_url": "https://microsoftedge.microsoft.com/addons",
+    "note": "Store pages are at https://microsoftedge.microsoft.com/addons/detail/<slug>/<extension-id>. There is no officially documented API, and only the latest version of an extension is publicly available."
+  },
+  "namespace_definition": {
+    "requirement": "prohibited",
+    "note": "There is no namespace"
+  },
+  "name_definition": {
+    "native_name": "extension_id",
+    "requirement": "required",
+    "permitted_characters": "^[a-p]{32}$",
+    "case_sensitive": false,
+    "note": "The name is the extension ID: 32 characters in the range a-p (base16-encoded with letters instead of hex digits), the same format as Chrome extension IDs, and is case insensitive. This is not the same as the display name, which is human readable and may vary with locale. The extension ID is the last path segment of the store page URL."
+  },
+  "version_definition": {
+    "native_name": "version",
+    "requirement": "optional",
+    "permitted_characters": "^\\d+(\\.\\d+){0,3}$",
+    "note": "The edge extension version is semver-like but 1-4 segments, following the same manifest version format as Chrome extensions. When the version is omitted, the PURL references the latest version. See https://developer.chrome.com/docs/extensions/reference/manifest/version"
+  },
+  "examples": [
+    "pkg:edge-extension/odfafepnkmbhccpbejgmiehpchacaeak@1.72.2",
+    "pkg:edge-extension/cimighlppcgcoapaliogpjjdehbnofhn@2026.714.1952",
+    "pkg:edge-extension/nffknjpglkklphnibdiadeeeeailfnog@25.5.0",
+    "pkg:edge-extension/odfafepnkmbhccpbejgmiehpchacaeak"
+  ],
+  "reference_urls": [
+    "https://learn.microsoft.com/en-us/microsoft-edge/extensions/",
+    "https://developer.chrome.com/docs/extensions/reference/manifest/version",
+    "https://github.com/chromium/chromium/blob/main/docs/updater/protocol_3_1.md"
+  ]
+}


### PR DESCRIPTION
This PR registers a new PURL **type** for Microsoft Edge Browser Extensions (Add-ons), as distributed via the [Microsoft Edge Add-ons store](https://microsoftedge.microsoft.com/addons). It follows the recently merged `chrome-extension` type (#522) very closely, and answers the questions from the [Register new PURL type](https://github.com/package-url/purl-spec/blob/main/.github/ISSUE_TEMPLATE/Register%20new%20PURL%20type.md) template below.

- [x] Why is this new PURL **type** needed?
- [x] What are the PURL component level definitions?
- [x] What input do you have from the relevant package ecosystem/community?
- [x] Are there any open questions or concerns about this new PURL **type**?

## Why is this new PURL type needed?

Browser extensions are installable, versioned software packages and an increasingly important software supply chain surface. The `chrome-extension` type was registered in #522; the Microsoft Edge Add-ons store is a separate marketplace with its own catalog, listings, and review process — the same extension ID can exist in one store and not the other, and versions can differ between stores — so identifying an Edge Add-on requires its own PURL type even though the underlying formats match Chrome's.

## What are the PURL component level definitions?

Full definition in [`types/edge-extension-definition.json`](https://github.com/annextuckner/purl-spec/blob/add-edge-extension-type/types/edge-extension-definition.json), with generated docs and test cases included in this PR. Edge extensions share Chrome's CRX packaging, extension ID format, and manifest version format, so the definitions intentionally mirror `chrome-extension`.

| Component | Definition |
|---|---|
| `type` | `edge-extension` (descriptive `<browser>-extension` naming per #522 / #673 feedback) |
| `namespace` | Prohibited — there is no namespace |
| `name` | **Required.** The extension ID: 32 characters in the range a-p (base16-encoded with letters instead of hex digits), same format as Chrome extension IDs; case insensitive. It is the last path segment of the store page URL. `permitted_characters`: `^[a-p]{32}$` |
| `version` | **Optional** (omitted = latest). Semver-like, 1–4 dot-separated numbers, same [manifest version format](https://developer.chrome.com/docs/extensions/reference/manifest/version) as Chrome. `permitted_characters`: `^\d+(\.\d+){0,3}$` |
| `qualifiers` / `subpath` | None defined |
| repository | `https://microsoftedge.microsoft.com/addons` — no officially documented API; known data sources are the product details endpoint at `https://microsoftedge.microsoft.com/addons/getproductdetailsbycrxid/<extension-id>` and an updatecheck-style endpoint at `https://edge.microsoft.com/extensionwebstorebase/v1/crx` following the same [Omaha/updater protocol](https://github.com/chromium/chromium/blob/main/docs/updater/protocol_3_1.md) as the Chrome Web Store. |

Example PURLs (all real, verified against the store's product details endpoint):

- `pkg:edge-extension/odfafepnkmbhccpbejgmiehpchacaeak@1.72.2` (uBlock Origin)
- `pkg:edge-extension/cimighlppcgcoapaliogpjjdehbnofhn@2026.714.1952` (uBlock Origin Lite)
- `pkg:edge-extension/nffknjpglkklphnibdiadeeeeailfnog@25.5.0` (uBlock)
- `pkg:edge-extension/odfafepnkmbhccpbejgmiehpchacaeak` (latest)

## What input do you have from the relevant package ecosystem/community?

- In #522, @patrickkettner (Chrome extensions team) explicitly noted that "the Edge marketplace and mozilla add-on store would share identical logic to what you created" — Edge is Chromium-based and consumes the same CRX/manifest formats this definition relies on.
- The definitions mirror the vendor-reviewed `chrome-extension` type registered in #522.
- No direct review from Microsoft staff yet — happy to seek input from the Edge extensions team if maintainers want vendor sign-off as was done for #522.

## Are there any open questions or concerns about this new PURL type?

- **Undocumented store API**: like the Chrome Web Store, the Edge Add-ons store has no officially documented API and only exposes the latest version publicly; the known endpoints are documented in the definition's notes (same approach #522 took for Chrome's updatecheck API).
- **Same ID space as Chrome, different catalogs**: an extension ported from Chrome may keep the same 32-character ID or get a new one when published to the Edge store, which is exactly why the store is captured in the PURL `type` rather than a qualifier.

## Checks

Docs and `purl-types-index.json` regenerated with `make gendocs`; `make checkjson` passes; roundtrip canonicalization of all valid test cases verified with packageurl-python.

A sibling PR (#927) adds `firefox-extension` for addons.mozilla.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)