### PR TITLE
Fix erroneous test schema filenames

### DIFF
--- a/tests/types/chrome-extension-test.json
+++ b/tests/types/chrome-extension-test.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://packageurl.org/schemas/purl-test.schema-1.0.json",
+  "$schema": "https://packageurl.org/schemas/purl-test.schema-0.1.json",
   "tests": [
     {
       "description": "valid chrome purl (version: full)",

--- a/tests/types/vscode-extension-test.json
+++ b/tests/types/vscode-extension-test.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://packageurl.org/schemas/purl-test.schema-1.0.json",
+  "$schema": "https://packageurl.org/schemas/purl-test.schema-0.1.json",
   "tests": [
     {
       "description": "Parse test for basic VS Code Extension PURL with version",


### PR DESCRIPTION
- change 'purl-test.schema-1.0.json' to 'purl-test.schema-0.1.json'