### PR TITLE
Fix "git" roundtrip test

### DIFF
--- a/tests/types/git-test.json
+++ b/tests/types/git-test.json
@@ -2,7 +2,7 @@
   "$schema": "https://packageurl.org/schemas/purl-test.schema-0.2.json",
   "tests": [
     {
-      "description": "git namespace and name should be lowercased. Roundtrip an input purl to canonical.",
+      "description": "git namespace and name should be lowercased. Validate an input purl.",
       "test_group": "recommended",
       "test_type": "validate",
       "input": "pkg:git/github/Package-url/purl-Spec@244fd47e07d1004f0aed9c",
@@ -27,7 +27,7 @@
       "expected_message": null
     },
     {
-      "description": "Roundtrip test for PURL type: git",
+      "description": "Validate test for PURL type: git",
       "test_group": "required",
       "test_type": "validate",
       "input": "pkg:git/codeberg.org/forgejo/forgejo@a72d2c07cfca03b55371089de6aa230d8c951fa0",
@@ -68,7 +68,7 @@
       "expected_message": null
     },
     {
-      "description": "Roundtrip test for PURL type: git",
+      "description": "Validate test for PURL type: git",
       "test_group": "required",
       "test_type": "validate",
       "input": "pkg:git/codeberg.org/forgejo/forgejo@a72d2c07cfca03b55371089de6aa230d8c951fa0#options/locale_readme.md",

--- a/tests/types/git-test.json
+++ b/tests/types/git-test.json
@@ -72,7 +72,7 @@
       "test_group": "required",
       "test_type": "validate",
       "input": "pkg:git/codeberg.org/forgejo/forgejo@a72d2c07cfca03b55371089de6aa230d8c951fa0#options/locale_readme.md",
-      "expected_output": "pkg:git/codeberg.org/forgejoforgejo/@a72d2c07cfca03b55371089de6aa230d8c951fa0#options/locale_readme.md",
+      "expected_output": "pkg:git/codeberg.org/forgejo/forgejo@a72d2c07cfca03b55371089de6aa230d8c951fa0#options/locale_readme.md",
       "expected_failure": false,
       "expected_message": null
     },


### PR DESCRIPTION
Fixed roudtrip test in "git" PURL type.

```
$ PURL_TYPE=git prove -l t/99-purl-tests.t 
t/99-purl-tests.t .. 1/? # Test only git testcases

#   Failed test 'validate [required] Roundtrip test for PURL type: git'
#   at t/99-purl-tests.t line 149.
#          got: 'pkg:git/codeberg.org/forgejo/forgejo@a72d2c07cfca03b55371089de6aa230d8c951fa0#options/locale_readme.md'
#     expected: 'pkg:git/codeberg.org/forgejoforgejo/@a72d2c07cfca03b55371089de6aa230d8c951fa0#options/locale_readme.md'
# Test only git testcases
# Looks like you failed 1 test of 38.
t/99-purl-tests.t .. Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/38 subtests 

Test Summary Report
-------------------
t/99-purl-tests.t (Wstat: 256 (exited 1) Tests: 38 Failed: 1)
  Failed test:  15
  Non-zero exit status: 1
Files=1, Tests=38,  0 wallclock secs ( 0.03 usr  0.00 sys +  0.15 cusr  0.01 csys =  0.19 CPU)
Result: FAIL
```