### PR TITLE
Fix error in RPM test suite.

### DIFF
--- a/tests/types/rpm-test.json
+++ b/tests/types/rpm-test.json
@@ -15,19 +15,8 @@
       "test_group": "required",
       "test_type": "parse",
       "input": "pkg:Rpm/fedora/curl@7.50.3-1.fc25?Arch=i386&Distro=fedora-25",
-      "expected_output": {
-        "type": "rpm",
-        "namespace": "fedora",
-        "name": "curl",
-        "version": "7.50.3-1.fc25",
-        "qualifiers": {
-          "arch": "i386",
-          "distro": "fedora-25"
-        },
-        "subpath": null
-      },
-      "expected_failure": false,
-      "expected_message": null
+      "expected_failure": true,
+      "expected_message": "Should fail as qualifier keys are not in lowercase"
     },
     {
       "description": "rpm often use qualifiers. Roundtrip a canonical input to canonical output.",


### PR DESCRIPTION
One of the tests (with type `required`) has invalid qualifier keys (not in lowercase), but did not expect a failure. This was fixed by updating the test to a failing `required` test as discussed in issue #942 (original repository).