### PR TITLE
Fix swid example

### DIFF
--- a/types/swid-definition.json
+++ b/types/swid-definition.json
@@ -55,7 +55,7 @@
   ],
   "note": "Use of known qualifiers key/value pairs such as download_url can be used to specify where the package was retrieved from.",
   "examples": [
-    "pkg:swid/Acme/example.com/Enterprise+Server@1.0.0?tag_id=75b8c285-fa7b-485b-b199-4745e3004d0d",
+    "pkg:swid/Acme/example.com/Enterprise%2BServer@1.0.0?tag_id=75b8c285-fa7b-485b-b199-4745e3004d0d",
     "pkg:swid/Fedora@29?tag_id=org.fedoraproject.Fedora-29",
     "pkg:swid/Adobe%2BSystems%2BIncorporated/Adobe%2BInDesign@CC?tag_id=CreativeCloud-CS6-Win-GM-MUL"
   ]


### PR DESCRIPTION
First example PURL for swid contains 'Enterprise+Server' as package name, which is not percent-encoded. This commit fixes #948.