### PR TITLE
Fix bug in gem test suite (See #942).

### DIFF
--- a/tests/types/gem-test.json
+++ b/tests/types/gem-test.json
@@ -15,18 +15,8 @@
       "test_group": "required",
       "test_type": "parse",
       "input": "pkg:gem/jruby-launcher@1.1.2?Platform=java",
-      "expected_output": {
-        "type": "gem",
-        "namespace": null,
-        "name": "jruby-launcher",
-        "version": "1.1.2",
-        "qualifiers": {
-          "platform": "java"
-        },
-        "subpath": null
-      },
-      "expected_failure": false,
-      "expected_message": null
+      "expected_failure": true,
+      "expected_message": "Should fail due to qualifier key not in lowercase"
     },
     {
       "description": "Ruby gems can use qualifiers. Roundtrip a canonical input to canonical output.",


### PR DESCRIPTION
A `required` `parse` test accepted a PURL with a qualifier key not in lowercase. This commit changes the test to expect a failure.

See [my comment](https://github.com/package-url/purl-spec/issues/942#issuecomment-5260073393) in #942.