### PR TITLE
Update "must" to "shall"

### DIFF
--- a/types/alpm-definition.json
+++ b/types/alpm-definition.json
@@ -14,12 +14,12 @@
     "case_sensitive": false,
     "native_name": "vendor",
     "normalization_rules": [
-      "It is not case sensitive and must be lowercased."
+      "It is not case sensitive and shall be lowercased."
     ]
   },
   "name_definition": {
     "requirement": "required",
-    "note": "The name is the package name. It is not case sensitive and must be lowercased.",
+    "note": "The name is the package name. It is not case sensitive and shall be lowercased.",
     "case_sensitive": false,
     "native_name": "name"
   },

--- a/types/apk-definition.json
+++ b/types/apk-definition.json
@@ -10,13 +10,13 @@
   },
   "namespace_definition": {
     "requirement": "required",
-    "note": "The namespace is the vendor such as alpine or openwrt. It is not case sensitive and must be lowercased.",
+    "note": "The namespace is the vendor such as alpine or openwrt. It is not case sensitive and shall be lowercased.",
     "native_name": "vendor",
     "case_sensitive": false
   },
   "name_definition": {
     "requirement": "required",
-    "note": "The name is the package name. It is not case sensitive and must be lowercased.",
+    "note": "The name is the package name. It is not case sensitive and shall be lowercased.",
     "native_name": "name",
     "case_sensitive": false
   },

--- a/types/bazel-definition.json
+++ b/types/bazel-definition.json
@@ -24,7 +24,7 @@
   "subpath_definition": {
     "requirement": "optional",
     "native_name": "label",
-    "note": "The optional subpath MAY refer to a label of a particular package or target in the module (https://bazel.build/concepts/labels). The label MUST NOT include a repo name and the leading '//' MUST be omitted. When referring to targets, the label MUST include the name of the target, separated from the package by ':'. If there is no target name, subpath is assumed to refer to the whole package."
+    "note": "The optional subpath MAY refer to a label of a particular package or target in the module (https://bazel.build/concepts/labels). The label shall NOT include a repo name and the leading '//' shall be omitted. When referring to targets, the label shall include the name of the target, separated from the package by ':'. If there is no target name, subpath is assumed to refer to the whole package."
   },
   "qualifiers_definition": [
     {

--- a/types/bitbucket-definition.json
+++ b/types/bitbucket-definition.json
@@ -10,13 +10,13 @@
   },
   "namespace_definition": {
     "requirement": "required",
-    "note": "The namespace is the user or organization. It is not case sensitive and must be lowercased.",
+    "note": "The namespace is the user or organization. It is not case sensitive and shall be lowercased.",
     "native_name": "user or organization",
     "case_sensitive": false
   },
   "name_definition": {
     "requirement": "required",
-    "note": "The name is the repository name. It is not case sensitive and must be lowercased.",
+    "note": "The name is the repository name. It is not case sensitive and shall be lowercased.",
     "native_name": "repository name",
     "case_sensitive": false
   },

--- a/types/bitnami-definition.json
+++ b/types/bitnami-definition.json
@@ -14,7 +14,7 @@
   },
   "name_definition": {
     "requirement": "required",
-    "note": "The name is the component name. It must be lowercased.",
+    "note": "The name is the component name. It shall be lowercased.",
     "case_sensitive": false,
     "native_name": "name"
   },

--- a/types/brew-definition.json
+++ b/types/brew-definition.json
@@ -13,13 +13,13 @@
     "requirement": "optional",
     "native_name": "tap",
     "case_sensitive": false,
-    "note": "The namespace is the Homebrew tap name, typically in the format 'owner/repo' (e.g., 'homebrew/core', 'some-org/some-tap'). It is not case sensitive and must be lowercased. When not specified, formulas are assumed to come from the default 'homebrew/core' tap."
+    "note": "The namespace is the Homebrew tap name, typically in the format 'owner/repo' (e.g., 'homebrew/core', 'some-org/some-tap'). It is not case sensitive and shall be lowercased. When not specified, formulas are assumed to come from the default 'homebrew/core' tap."
   },
   "name_definition": {
     "requirement": "required",
     "native_name": "formula",
     "case_sensitive": false,
-    "note": "The name is the Homebrew formula or cask name. It is not case sensitive and must be lowercased. Formula names containing '@' (used for versioned formulas like 'postgresql@12') must have the '@' character percent-encoded as '%40' in the PURL string."
+    "note": "The name is the Homebrew formula or cask name. It is not case sensitive and shall be lowercased. Formula names containing '@' (used for versioned formulas like 'postgresql@12') shall have the '@' character percent-encoded as '%40' in the PURL string."
   },
   "version_definition": {
     "requirement": "optional",

--- a/types/composer-definition.json
+++ b/types/composer-definition.json
@@ -12,13 +12,13 @@
     "requirement": "required",
     "case_sensitive": false,
     "native_name": "vendor",
-    "note": "The namespace is the vendor. The namespace is not case sensitive and must be lowercased."
+    "note": "The namespace is the vendor. The namespace is not case sensitive and shall be lowercased."
   },
   "name_definition": {
     "requirement": "required",
     "case_sensitive": false,
     "native_name": "name",
-    "note": "The name is not case sensitive and must be lowercased. Private, local packages may have no name. In this case you cannot create a purl for these."
+    "note": "The name is not case sensitive and shall be lowercased. Private, local packages may have no name. In this case you cannot create a purl for these."
   },
   "version_definition": {
     "requirement": "optional",

--- a/types/cpan-definition.json
+++ b/types/cpan-definition.json
@@ -11,13 +11,13 @@
   "namespace_definition": {
     "requirement": "optional",
     "native_name": "CPAN author/publisher ID (CPANID)",
-    "note": "When present, it represents the CPAN author/publisher ID (CPANID) and MUST be uppercase. It is appropriate to use 'namespace' for compatibility with existing CPAN purl producers/consumers or when a workflow explicitly requires author-scoped identifiers. For new identifiers, the 'author' qualifier is the preferred way to specify the author/publisher. When 'version' is omitted, author scoping via 'namespace' MAY be ambiguous because a distribution can change maintainers over time."
+    "note": "When present, it represents the CPAN author/publisher ID (CPANID) and shall be uppercase. It is appropriate to use 'namespace' for compatibility with existing CPAN purl producers/consumers or when a workflow explicitly requires author-scoped identifiers. For new identifiers, the 'author' qualifier is the preferred way to specify the author/publisher. When 'version' is omitted, author scoping via 'namespace' MAY be ambiguous because a distribution can change maintainers over time."
   },
   "name_definition": {
     "requirement": "required",
     "case_sensitive": true,
     "native_name": "distribution name",
-    "note": "The name is the distribution name and is case sensitive. A distribution name MUST NOT contain the string '::'"
+    "note": "The name is the distribution name and is case sensitive. A distribution name shall NOT contain the string '::'"
   },
   "version_definition": {
     "note": "The version is the distribution version",
@@ -57,7 +57,7 @@
       "default_value": "tar.gz"
     }
   ],
-  "note":"The PURL 'name' MUST be the CPAN distribution name (case sensitive) and MUST NOT contain the '::' separator (module name). The CPAN author/publisher ID (CPANID) is OPTIONAL: when needed, it SHOULD be provided using the 'author' qualifier. The PURL 'namespace' is OPTIONAL and, when present, represents the CPANID and MUST be uppercase; it MAY be used for compatibility with existing identifiers or tooling. When PURL 'version' is omitted, author scoping (via 'author' qualifier or 'namespace') MAY be ambiguous because a distribution can change maintainers over time.",
+  "note":"The PURL 'name' shall be the CPAN distribution name (case sensitive) and shall NOT contain the '::' separator (module name). The CPAN author/publisher ID (CPANID) is OPTIONAL: when needed, it SHOULD be provided using the 'author' qualifier. The PURL 'namespace' is OPTIONAL and, when present, represents the CPANID and shall be uppercase; it MAY be used for compatibility with existing identifiers or tooling. When PURL 'version' is omitted, author scoping (via 'author' qualifier or 'namespace') MAY be ambiguous because a distribution can change maintainers over time.",
   "examples": [
     "pkg:cpan/perl@5.42",
     "pkg:cpan/DBI@1.646",

--- a/types/deb-definition.json
+++ b/types/deb-definition.json
@@ -11,14 +11,14 @@
   "namespace_definition": {
     "native_name": "vendor",
     "case_sensitive": false,
-    "note": "The namespace is the \"vendor\" name such as \"debian\" or \"ubuntu\". It is not case sensitive and must be lowercased.",
+    "note": "The namespace is the \"vendor\" name such as \"debian\" or \"ubuntu\". It is not case sensitive and shall be lowercased.",
     "requirement": "required"
   },
   "name_definition": {
     "requirement": "required",
     "native_name": "name",
     "case_sensitive": false,
-    "note": "The name is not case sensitive and must be lowercased."
+    "note": "The name is not case sensitive and shall be lowercased."
   },
   "version_definition": {
     "requirement": "optional",

--- a/types/github-definition.json
+++ b/types/github-definition.json
@@ -12,13 +12,13 @@
     "requirement": "required",
     "case_sensitive": false,
     "native_name": "user or organization",
-    "note": "The namespace is the user or organization. It is not case sensitive and must be lowercased."
+    "note": "The namespace is the user or organization. It is not case sensitive and shall be lowercased."
   },
   "name_definition": {
     "requirement": "required",
     "case_sensitive": false,
     "native_name": "repository name",
-    "note": "The name is the repository name. It is not case sensitive and must be lowercased."
+    "note": "The name is the repository name. It is not case sensitive and shall be lowercased."
   },
   "version_definition": {
     "requirement": "optional",

--- a/types/golang-definition.json
+++ b/types/golang-definition.json
@@ -11,12 +11,12 @@
   "namespace_definition": {
     "requirement": "required",
     "case_sensitive": true,
-    "note": "The namespace must be lowercased."
+    "note": "The namespace shall be lowercased."
   },
   "name_definition": {
     "requirement": "required",
     "case_sensitive": true,
-    "note": "The name must be lowercased."
+    "note": "The name shall be lowercased."
   },
   "subpath_definition": {
     "requirement": "optional",

--- a/types/hex-definition.json
+++ b/types/hex-definition.json
@@ -12,13 +12,13 @@
     "requirement": "optional",
     "case_sensitive": false,
     "native_name": "organization for private packages",
-    "note": "The namespace is optional; it may be used to specify the organization for private packages on hex.pm. It is not case sensitive and must be lowercased."
+    "note": "The namespace is optional; it may be used to specify the organization for private packages on hex.pm. It is not case sensitive and shall be lowercased."
   },
   "name_definition": {
     "requirement": "required",
     "case_sensitive": false,
     "native_name": "name",
-    "note": "The name is not case sensitive and must be lowercased."
+    "note": "The name is not case sensitive and shall be lowercased."
   },
   "version_definition": {
     "requirement": "optional",

--- a/types/huggingface-definition.json
+++ b/types/huggingface-definition.json
@@ -24,7 +24,7 @@
     "requirement": "optional",
     "case_sensitive": false,
     "native_name": "model revision Git commit hash",
-    "note": "The version is the model revision Git commit hash. It is case insensitive and must be lowercased in the package URL."
+    "note": "The version is the model revision Git commit hash. It is case insensitive and shall be lowercased in the package URL."
   },
   "examples": [
     "pkg:huggingface/distilbert/distilbert-base-uncased@043235d6088ecd3dd5fb5ca3592b6913fd516027",

--- a/types/luarocks-definition.json
+++ b/types/luarocks-definition.json
@@ -23,7 +23,7 @@
     "requirement": "optional",
     "case_sensitive": true,
     "native_name": "full package version, including module version and rockspec revision",
-    "note": "The full LuaRocks package version, including module version and rockspec revision. It is case sensitive, and lowercase must be used to avoid compatibility issues with older LuaRocks versions. The full version number is required to uniquely identify a version."
+    "note": "The full LuaRocks package version, including module version and rockspec revision. It is case sensitive, and lowercase shall be used to avoid compatibility issues with older LuaRocks versions. The full version number is required to uniquely identify a version."
   },
   "qualifiers_definition": [
     {

--- a/types/mlflow-definition.json
+++ b/types/mlflow-definition.json
@@ -14,7 +14,7 @@
   },
   "name_definition": {
     "requirement": "required",
-    "note": "The name is the model name. Case sensitivity depends on the server implementation, such as for Azure ML, it is case sensitive and must be kept as-is in the package URL; and for Databricks, it is case insensitive and must be lowercased in the package URL."
+    "note": "The name is the model name. Case sensitivity depends on the server implementation, such as for Azure ML, it is case sensitive and shall be kept as-is in the package URL; and for Databricks, it is case insensitive and shall be lowercased in the package URL."
   },
   "version_definition": {
     "requirement": "optional",

--- a/types/npm-definition.json
+++ b/types/npm-definition.json
@@ -19,7 +19,7 @@
     "requirement": "required",
     "case_sensitive": true,
     "native_name": "name",
-    "note": "The package.json spec changed in 2015 to require that a new package 'must not have uppercase letters in the name', but old packages with mixed case names were \"grandfathered in\"."
+    "note": "The package.json spec changed in 2015 to require that a new package 'shall not have uppercase letters in the name', but old packages with mixed case names were \"grandfathered in\"."
   },
   "version_definition": {
     "requirement": "optional",

--- a/types/oci-definition.json
+++ b/types/oci-definition.json
@@ -6,7 +6,7 @@
   "description": "For artifacts stored in registries that conform to the OCI Distribution Specification https://github.com/opencontainers/distribution-spec including container images built by Docker and others",
   "repository": {
     "use_repository": true,
-    "note": "There is no canonical package repository for OCI artifacts. Therefore oci purls must be registry agnostic by default. To specify the repository, provide a repository_url value."
+    "note": "There is no canonical package repository for OCI artifacts. Therefore oci purls shall be registry agnostic by default. To specify the repository, provide a repository_url value."
   },
   "namespace_definition": {
     "requirement": "prohibited",
@@ -15,7 +15,7 @@
   "name_definition": {
     "requirement": "required",
     "case_sensitive": false,
-    "note": "The name is not case sensitive and must be lowercased. The name is the last fragment of the repository name. For example if the repository name is library/debian then the name is debian."
+    "note": "The name is not case sensitive and shall be lowercased. The name is the last fragment of the repository name. For example if the repository name is library/debian then the name is debian."
   },
   "version_definition": {
     "requirement": "optional",

--- a/types/otp-definition.json
+++ b/types/otp-definition.json
@@ -10,12 +10,12 @@
   },
   "namespace_definition": {
     "requirement": "prohibited",
-    "note": "The component is unused and MUST be empty"
+    "note": "The component is unused and shall be empty"
   },
   "name_definition": {
     "case_sensitive": false,
     "native_name": "name",
-    "note": "The OTP application name from the `.app` file; it is case-insensitive and MUST be lower-cased.",
+    "note": "The OTP application name from the `.app` file; it is case-insensitive and shall be lower-cased.",
     "requirement": "required"
   },
   "version_definition": {

--- a/types/pypi-definition.json
+++ b/types/pypi-definition.json
@@ -21,7 +21,7 @@
       "Replace underscore _ with dash -",
       "Replace dot . with underscore _ when used in distribution (sdist, wheel) names"
     ],
-    "note": "PyPI treats - and _ as the same character and is not case sensitive. Therefore a PyPI package name must be lowercased and underscore _ replaced with a dash -. Note that PyPI itself is preserving the case of package names. When used in distribution and wheel names, the dot . is replaced with an underscore _"
+    "note": "PyPI treats - and _ as the same character and is not case sensitive. Therefore a PyPI package name shall be lowercased and underscore _ replaced with a dash -. Note that PyPI itself is preserving the case of package names. When used in distribution and wheel names, the dot . is replaced with an underscore _"
   },
   "version_definition": {
     "requirement": "optional",

--- a/types/qpkg-definition.json
+++ b/types/qpkg-definition.json
@@ -11,7 +11,7 @@
   "namespace_definition": {
     "case_sensitive": false,
     "native_name": "vendor",
-    "note": "The namespace is the vendor of the package. It is not case sensitive and must be lowercased.",
+    "note": "The namespace is the vendor of the package. It is not case sensitive and shall be lowercased.",
     "requirement": "required"
   },
   "name_definition": {

--- a/types/rpm-definition.json
+++ b/types/rpm-definition.json
@@ -11,7 +11,7 @@
   "namespace_definition": {
     "case_sensitive": false,
     "native_name": "vendor",
-    "note": "The namespace is the vendor such as Fedora or OpenSUSE. It is not case sensitive and must be lowercased.",
+    "note": "The namespace is the vendor such as Fedora or OpenSUSE. It is not case sensitive and shall be lowercased.",
     "requirement": "required"
   },
   "name_definition": {

--- a/types/swid-definition.json
+++ b/types/swid-definition.json
@@ -12,7 +12,7 @@
     "requirement": "optional",
     "case_sensitive": true,
     "native_name": "softwareCreator",
-    "note": "The namespace is the optional name and regid of the entity with a role of softwareCreator. If specified, name is required and is the first segment in the namespace. If regid is known, it must be specified as the second segment in the namespace. A maximum of two segments are supported."
+    "note": "The namespace is the optional name and regid of the entity with a role of softwareCreator. If specified, name is required and is the first segment in the namespace. If regid is known, it shall be specified as the second segment in the namespace. A maximum of two segments are supported."
   },
   "name_definition": {
     "requirement": "required",
@@ -30,7 +30,7 @@
     {
       "key": "tag_id",
       "requirement": "required",
-      "description": "The qualifier tag_id must not be empty and corresponds to the tagId as defined in the SWID SoftwareIdentity element. Per the SWID specification, GUIDs are recommended. If a GUID is used, it must be lowercase. If a GUID is not used, the tag_id qualifier is case aware but not case sensitive."
+      "description": "The qualifier tag_id shall not be empty and corresponds to the tagId as defined in the SWID SoftwareIdentity element. Per the SWID specification, GUIDs are recommended. If a GUID is used, it shall be lowercase. If a GUID is not used, the tag_id qualifier is case aware but not case sensitive."
     },
     {
       "key": "tag_version",

--- a/types/vcpkg-definition.json
+++ b/types/vcpkg-definition.json
@@ -42,7 +42,7 @@
       "description": "The vcpkg [triplet](https://learn.microsoft.com/vcpkg/concepts/triplets) describing the target build configuration (architecture, operating system, and CRT/library linkage), for example `x64-windows` or `arm64-osx`. It describes the build target and does not affect package identity."
     }
   ],
-  "note": "A purl may carry extra qualifiers that describe the context in which the package is used, such as build configuration or platform. Parsers must tolerate these and may ignore any they do not expect. The `vcs_url` common qualifier carries the port's version-control URL in pip VCS form, for example `git+https://github.com/microsoft/vcpkg@<git-tree>`. Its git-tree pins the exact port recipe. The `features` qualifier, a comma-separated list of enabled vcpkg feature names, records which optional features were enabled at build time; it is informational and not currently normative.",
+  "note": "A purl may carry extra qualifiers that describe the context in which the package is used, such as build configuration or platform. Parsers shall tolerate these and may ignore any they do not expect. The `vcs_url` common qualifier carries the port's version-control URL in pip VCS form, for example `git+https://github.com/microsoft/vcpkg@<git-tree>`. Its git-tree pins the exact port recipe. The `features` qualifier, a comma-separated list of enabled vcpkg feature names, records which optional features were enabled at build time; it is informational and not currently normative.",
   "examples": [
     "pkg:vcpkg/bzip2@1.0.8?port_version=6",
     "pkg:vcpkg/zlib@1.3.1?triplet=x64-linux&vcs_url=git%2Bhttps:%2F%2Fgithub.com%2Fmicrosoft%2Fvcpkg%40b5d3197b1a8a3f4c2d9e0f1a2b3c4d5e6f708192",

--- a/types/yocto-definition.json
+++ b/types/yocto-definition.json
@@ -29,7 +29,7 @@
     {
       "key": "repository_url",
       "requirement": "optional",
-      "description": "The GIT URL of the layer. In example: https:%2F%2Fgit.openembedded.org%2Fopenembedded-core or https:%2F%2Fgithub.com%2Fakuster%2Fmeta-odroid. The URL scheme is mandatory and must be one of https, http, ssh, or git."
+      "description": "The GIT URL of the layer. In example: https:%2F%2Fgit.openembedded.org%2Fopenembedded-core or https:%2F%2Fgithub.com%2Fakuster%2Fmeta-odroid. The URL scheme is mandatory and shall be one of https, http, ssh, or git."
     },
     {
       "key": "layer_version",


### PR DESCRIPTION
Updated all occurrences of "must" to "shall" for conformance with Ecma terminology.
This is a follow up to:
= #933 
where I mistakenly updated the generated markdown files instead of the JSON definition files.