### PR TITLE
Reset to lowercase

### DIFF
--- a/types/bazel-definition.json
+++ b/types/bazel-definition.json
@@ -24,7 +24,7 @@
   "subpath_definition": {
     "requirement": "optional",
     "native_name": "label",
-    "note": "The optional subpath MAY refer to a label of a particular package or target in the module (https://bazel.build/concepts/labels). The label shall NOT include a repo name and the leading '//' shall be omitted. When referring to targets, the label shall include the name of the target, separated from the package by ':'. If there is no target name, subpath is assumed to refer to the whole package."
+    "note": "The optional subpath MAY refer to a label of a particular package or target in the module (https://bazel.build/concepts/labels). The label shall not include a repo name and the leading '//' shall be omitted. When referring to targets, the label shall include the name of the target, separated from the package by ':'. If there is no target name, subpath is assumed to refer to the whole package."
   },
   "qualifiers_definition": [
     {

--- a/types/cpan-definition.json
+++ b/types/cpan-definition.json
@@ -11,13 +11,13 @@
   "namespace_definition": {
     "requirement": "optional",
     "native_name": "CPAN author/publisher ID (CPANID)",
-    "note": "When present, it represents the CPAN author/publisher ID (CPANID) and shall be uppercase. It is appropriate to use 'namespace' for compatibility with existing CPAN purl producers/consumers or when a workflow explicitly requires author-scoped identifiers. For new identifiers, the 'author' qualifier is the preferred way to specify the author/publisher. When 'version' is omitted, author scoping via 'namespace' MAY be ambiguous because a distribution can change maintainers over time."
+    "note": "When present, it represents the CPAN author/publisher ID (CPANID) and shall be uppercase. It is appropriate to use 'namespace' for compatibility with existing CPAN purl producers/consumers or when a workflow explicitly requires author-scoped identifiers. For new identifiers, the 'author' qualifier is the preferred way to specify the author/publisher. When 'version' is omitted, author scoping via 'namespace' may be ambiguous because a distribution can change maintainers over time."
   },
   "name_definition": {
     "requirement": "required",
     "case_sensitive": true,
     "native_name": "distribution name",
-    "note": "The name is the distribution name and is case sensitive. A distribution name shall NOT contain the string '::'"
+    "note": "The name is the distribution name and is case sensitive. A distribution name shall not contain the string '::'"
   },
   "version_definition": {
     "note": "The version is the distribution version",
@@ -57,7 +57,7 @@
       "default_value": "tar.gz"
     }
   ],
-  "note":"The PURL 'name' shall be the CPAN distribution name (case sensitive) and shall NOT contain the '::' separator (module name). The CPAN author/publisher ID (CPANID) is OPTIONAL: when needed, it SHOULD be provided using the 'author' qualifier. The PURL 'namespace' is OPTIONAL and, when present, represents the CPANID and shall be uppercase; it MAY be used for compatibility with existing identifiers or tooling. When PURL 'version' is omitted, author scoping (via 'author' qualifier or 'namespace') MAY be ambiguous because a distribution can change maintainers over time.",
+  "note":"The PURL 'name' shall be the CPAN distribution name (case sensitive) and shall not contain the '::' separator (module name). The CPAN author/publisher ID (CPANID) is OPTIONAL: when needed, it should be provided using the 'author' qualifier. The PURL 'namespace' is OPTIONAL and, when present, represents the CPANID and shall be uppercase; it may be used for compatibility with existing identifiers or tooling. When PURL 'version' is omitted, author scoping (via 'author' qualifier or 'namespace') may be ambiguous because a distribution can change maintainers over time.",
   "examples": [
     "pkg:cpan/perl@5.42",
     "pkg:cpan/DBI@1.646",


### PR DESCRIPTION
Reset NOT, SHALL and SHOULD to lowercase. Ecma standard terminology does not uppercase these words.