### PR TITLE
Update $id in purl-type-definition.schema-1.1.json

### DIFF
--- a/schemas/purl-type-definition.schema-1.1.json
+++ b/schemas/purl-type-definition.schema-1.1.json
@@ -84,7 +84,7 @@
       "title": "PURL type definition id",
       "description": "The unique identifier URI for this PURL type definition.",
       "type": "string",
-      "pattern": "^https:\\/\\/packageurl\\.org/types/[a-z0-9-]+-definition\\.json$"
+      "pattern": "^https:\\/\\/packageurl\\.org/purl-types/[a-z0-9-]+-definition\\.json$"
     },
     "type": {
       "title": "PURL type",


### PR DESCRIPTION
Changed "pattern" for "$id" from:
 "https:\\/\\/packageurl\\.org/types/[a-z0-9-]+-definition\\.json$"
to:
 "https:\\/\\/packageurl\\.org/purl-types/[a-z0-9-]+-definition\\.json$"

to avoid conflict with VERS **type** definitions.