### PR TITLE
vscode: fix `default_repository_url`

### DIFF
--- a/types/vscode-extension-definition.json
+++ b/types/vscode-extension-definition.json
@@ -6,7 +6,7 @@
   "description": "VS Code Extension packages",
   "repository": {
     "use_repository": true,
-    "default_repository_url": "https://marketplace.visualstudio.com/vscode-extension"
+    "default_repository_url": "https://marketplace.visualstudio.com/vscode"
   },
   "namespace_definition": {
     "requirement": "required",


### PR DESCRIPTION
The vscode `default_repository_url` is invalid.
Likely a accidental edit when we migrated `vscode` => `vscode-extension` 

https://marketplace.visualstudio.com/vscode-extension => 404
https://marketplace.visualstudio.com/vscode => 200
