### PR TITLE
Update Clause-6-Package-URL-Type-Definition-Schema.md

### DIFF
--- a/docs/specification/standard/Clause-6-Package-URL-Type-Definition-Schema.md
+++ b/docs/specification/standard/Clause-6-Package-URL-Type-Definition-Schema.md
@@ -1,6 +1,6 @@
 **6 Package-URL Type Definition Schema**
 
-The PURL Type Definition JSON Schema is the reference data model that is used to define PURL types in a structured way. Each PURL type is specified in a JSON document that matches this schema. These JSON documents are then used to generate PURL type documentation and to support PURL libraries and tools so that they can more easily parse, build, and validate PURLs by type in a consistent and standardized manner across programing languages and technology stacks.
+The PURL Type Definition JSON Schema is the reference data model that is used to define PURL types in a structured way. Each PURL type is specified in a JSON document that matches this schema. These JSON documents are then used to generate PURL type documentation and to support PURL libraries and tools so that they can more easily parse, build, and validate PURLs by type in a consistent and standardized manner across programming languages and technology stacks.
 
 **Location:** /  
 **Type:** Object


### PR DESCRIPTION
Corrected "programing" to "programming" in the first paragraph. 
I checked that this is the correct spelling per Oxford English. Apparently "programing" is a North American variant, rarely used.