### PR TITLE
Create Clause 5.7 for PURL type definitions

### DIFF
--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -12,12 +12,16 @@ There are two levels of PURL specification documentation:
   of the PURL Specification in other software or databases.
 
 ## ECMA-427 documentation
-ECMA-427 is the official documentation for the 1st edition of the Package-URL
-(PURL) Specification Standard. The source for this documentation is located
+ECMA-427 is the official documentation for the the Package-URL (PURL) Specification Standard. The source for this documentation is located
 at: https://github.com/Ecma-TC54/ECMA-427/blob/main/spec.html. The text from
 this HTML file is processed with several Ecma tools to produce a PDF file that
 is available from: https://tc54.org/purl/ and an HTML version at: https://ecma-tc54.github.io/ECMA-427/.
-These files map to ECMA-427 1st edition as follows:
+
+The purpose of keeping a copy of the ECMA-427 text here is to track
+changes at a more modular level than the EMCA-427 "source" code at: https://github.com/Ecma-TC54/ECMA-427/blob/main/spec.html in preparation for a new
+edition of ECMA-427.
+
+These files map to ECMA-427 2nd edition as follows:
 
 - About this specification: `About.md`
 - Introduction: `Introduction.md`
@@ -26,18 +30,16 @@ These files map to ECMA-427 1st edition as follows:
 - Clause 3 Normative references: `Clause-3-Normative-References.md`
 - Clause 4 Overview: `Clause-4-Overview.md`
 - Clause 5 Package-URL specification: `Clause-5-Package-URL-Specification.md`
-- Clause 6 Package-URL Type Definition Schema: `Clause-6-Package-URL-Type-Definition-Schema.md`
+- Clause 6 Package-URL Type Definition Schema:   `Clause-6-Package-URL-Type-Definition-Schema.md`
 - Annex A (normative) PURL Type Definition: `Annex-A-PURL-Type-Definition.md`
 - New for ECMA-427 2nd Edition
-  - Annex B (informative) PURL Standard Qualifiers: `Annex-B-Recommended-Qualifiers.md`
-  - Annex C (informative) PURL ABNF Grammar: *tbd*
-  
-The text in the `docs/specification/standard` files matches the official text
-with the following exceptions:
+  - Annex B (informative) PURL Standard Qualifiers:    `Annex-B-Recommended-Qualifiers.md`
+  - Annex C (informative) PURL ABNF Grammar: `Annex-C-ABNF-Grammar.md`
+
+The text formatting in the `docs/specification/standard` files matches the official text with some exceptions including:
 - examples are left-justified, not centered, to avoid using HTML tags for centering
-- the use of italics instead of intra-document links
+- italics are used instead of intra-document links
 - some other formatting differences between the official Ecmarkup format and markdown
 
-The purpose of keeping a copy of the ECMA-427 1st Edition text here is to track
-changes at a more modular level than the EMCA-427 "source" code at: https://github.com/Ecma-TC54/ECMA-427/blob/main/spec.html
+
 

--- a/docs/specification/standard/Annex-A-PURL-Type-Definition.md
+++ b/docs/specification/standard/Annex-A-PURL-Type-Definition.md
@@ -2,12 +2,12 @@
 This Annex provides a copy of the current Package-URL Type Definition Schema.
 The format is JSON Schema version draft-07.
 
-The schema shown below is available in electronic form at: https://github.com/package-url/purl-spec/blob/main/schemas/purl-type-definition.schema.json
+The schema shown below is available in electronic form at: https://github.com/package-url/purl-spec/blob/main/schemas/purl-type-definition.schema-1.1.json
 
 ~~~
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://packageurl.org/schemas/purl-type-definition.schema-1.0.json",
+  "$id": "https://packageurl.org/schemas/purl-type-definition.schema-1.1.json",
   "title": "Package-URL Type Definition",
   "description": "Schema to specify a Package-URL (PURL) type as a structured definition.",
   "type": "object",

--- a/docs/specification/standard/Clause-5-Package-URL-Specification.md
+++ b/docs/specification/standard/Clause-5-Package-URL-Specification.md
@@ -243,3 +243,25 @@ ignore and remove all such '/' characters.
     - may contain any Unicode character other than '/' unless the package's
       **type** definition further restricts the allowed characters.
 - The **subpath** shall be interpreted as relative to the root of the package.
+
+## 5.7 PURL type definitions
+This Standard includes the Package-URL Type Definition Schema but it does not
+include the set of current "registered" PURL **type** (JSON format) definition files because there are ongoing additions and changes to these files. The set of current "registered" PURL **type** definition files are located at: https://www.packageurl.org/purl-types/. Registration refers to the Package-URL
+community process for adding a new PURL **type**.
+
+There are two rules related to the set of registered PURL **type** definitions
+for conforming PURL implementations to validate the PURL **type** component of
+a PURL:
+- If the PURL **type** is registered, then the PURL is invalid if it does not
+  conform to all of the rules from the corresponding PURL **type** definition.
+- If the PURL **type** is not registered, then the **type** component is valid
+  if it conforms to the rules stated in the _Type_ component rules in this
+  Clause of the Standard.
+
+
+
+
+
+
+
+

--- a/docs/specification/standard/Clause-5-Package-URL-Specification.md
+++ b/docs/specification/standard/Clause-5-Package-URL-Specification.md
@@ -246,8 +246,10 @@ ignore and remove all such '/' characters.
 
 ## 5.7 PURL type definitions
 This Standard includes the Package-URL Type Definition Schema but it does not
-include the set of current "registered" PURL **type** (JSON format) definition files because there are ongoing additions and changes to these files. The set of current "registered" PURL **type** definition files are located at: https://www.packageurl.org/purl-types/. Registration refers to the Package-URL
-community process for adding a new PURL **type**.
+include the set of current "registered" PURL **type** (JSON format) definition 
+files because there are ongoing additions and changes to these files. The set 
+of current "registered" PURL **type** definition files are located at: https://www.packageurl.org/purl-types/. 
+Registration refers to the Package-URL community process for adding a new PURL **type**.
 
 There are two rules related to the set of registered PURL **type** definitions
 for conforming PURL implementations to validate the PURL **type** component of
@@ -256,7 +258,8 @@ a PURL:
   conform to all of the rules from the corresponding PURL **type** definition.
 - If the PURL **type** is not registered, then the **type** component is valid
   if it conforms to the rules stated in the _Type_ component rules in this
-  Clause of the Standard.
+  Clause of the Standard. In this case an implementation should report a
+  warning that the PURL **type** is not registered.
 
 
 


### PR DESCRIPTION
Added `docs/specification/standard/Clause-5-Package-URL-Specification.md`
Updated `docs/specification/README.md` to clarify that the files in `docs/specification/standard/` are the drafts for ECMA-427 2nd Edition