### PR TITLE
Add Annex C - ABNF Grammar and related docs

### DIFF
--- a/docs/specification/standard/Annex-C-ABNF-Grammar.md
+++ b/docs/specification/standard/Annex-C-ABNF-Grammar.md
@@ -1,5 +1,5 @@
 # Annex B (informative) ABNF Grammar
-This Annex documents the Augmented Backus Naur Form (ABNF) grammar
+This Annex documents the Augmented Backus Naur Form (ABNF) grammar for PURL strings.
 
 A valid PURL string adheres to the following grammar with the syntax defined
 according to [RFC 5234: Augmented BNF for Syntax Specifications: ABNF](https://datatracker.ietf.org/doc/html/rfc5234).

--- a/docs/specification/standard/Annex-C-ABNF-Grammar.md
+++ b/docs/specification/standard/Annex-C-ABNF-Grammar.md
@@ -1,0 +1,87 @@
+# Annex B (informative) ABNF Grammar
+This Annex documents the Augmented Backus Naur Form (ABNF) grammar
+
+A valid PURL string adheres to the following grammar with the syntax defined
+according to [RFC 5234: Augmented BNF for Syntax Specifications: ABNF](https://datatracker.ietf.org/doc/html/rfc5234).
+
+```abnf
+PURL = scheme ":" type
+       [ "/" namespace ] "/" name
+       [ "@" version ] [ "?" qualifiers ] [ "#" subpath ]
+
+; --- structure ---
+
+scheme = %x70.6B.67 ; constant with the value "pkg" (lowercase only)
+
+type = alpha-lc *( alpha-lc / DIGIT / "." / "-" )
+
+namespace = namespace-segment *( "/" namespace-segment )
+namespace-segment = 1*pchar-ns
+
+name = 1*pchar
+
+version = 1*pchar
+
+qualifiers = qualifier *( "&" qualifier )
+qualifier = qualifier-key "=" qualifier-value
+qualifier-key = alpha-lc *( alpha-lc / DIGIT / "." / "-" / "_" )
+qualifier-value = 1*pchar
+
+subpath = subpath-segment *( "/" subpath-segment )
+subpath-segment = subpath-segment-sc *pchar-ns     ; no leading "."
+                / "." subpath-segment-sc *pchar-ns ; forbid segment "."
+                / ".." 1*pchar-ns                  ; forbid segment ".."
+                       ; excludes the exact segments "." and ".."
+subpath-segment-sc = ( alphanumeric
+                     / "-" / "_" / "~"
+                     / colon ) ; = `unreserved` without "."
+                   / pct-encoded-ns
+                          ; safe characters
+
+; --- character classes ---
+
+alpha-lc     = %x61-7A ; lowercase a-z
+alphanumeric = ALPHA / DIGIT
+punctuation  = "." / "-" / "_" / "~"
+separator    = ":" / "/" / "@" / "?" / "=" / "&" / "#"
+colon        = ":"
+percent      = "%"
+
+unreserved = alphanumeric / punctuation / colon
+reserved   = "/" / "@" / "?" / "=" / "&" / "#"
+
+; `reserved` and `separator` are not referenced directly;
+; listed to document characters that require percent-encoding
+
+pchar    = unreserved / pct-encoded
+pchar-ns = unreserved / pct-encoded-ns
+; `-ns` suffix = variant that forbids the percent-encoded slash ("%2F")
+
+; --- percent-encoding ---
+
+pct-encoded    = pct-encoded-ns / percent "2" "F"
+pct-encoded-ns = percent (
+                      ( "0" / "1" ) HEXDIG
+                         ; %00-1F
+                    / "2" ( DIGIT / "A" / "B" / "C" )
+                         ; %20-2F except %2D ("-") and %2E (".") and %2F ("/")
+                    / "3" ( "B" / "C" / "D" / "E" / "F" )
+                         ; %30-3F except %30-39 (0-9) and %3A (":")
+                    / "4" "0"
+                         ; %40-4F except %41-4F (A-O)
+                    / "5" ( "B" / "C" / "D" / "E" )
+                         ; %50-5F except %50-5A (P-Z) and %5F ("_")
+                    / "6" "0"
+                         ; %60-6F except %61-6F (a-o)
+                    / "7" ( "B" / "C" / "D" / "F" )
+                         ; %70-7F except %70-7A (p-z) and %7E ("~")
+                    / ( "8" / "9" / "A" / "B" / "C" / "D" / "E" / "F" ) HEXDIG
+                         ; %80-FF
+                    )
+```
+Conformance to this grammar for valid PURL strings is necessary but not sufficient because the following constraints of the specification are not expressible in ABNF. These constraints apply in addition to the grammar.
+
+- Each `key` shall be unique within `qualifiers`.
+- The octets decoded from a sequence of `pct-encoded`/`pct-encoded-ns` shall
+  form a valid UTF-8 encoding per [RFC 3629](https://datatracker.ietf.org/doc/html/rfc3629).
+- **Type**-specific rules may further restrict any component.

--- a/docs/specification/standard/Annex-C-ABNF-Grammar.md
+++ b/docs/specification/standard/Annex-C-ABNF-Grammar.md
@@ -79,6 +79,7 @@ pct-encoded-ns = percent (
                          ; %80-FF
                     )
 ```
+
 Conformance to this grammar for valid PURL strings is necessary but not sufficient because the following constraints of the specification are not expressible in ABNF. These constraints apply in addition to the grammar.
 
 - Each `key` shall be unique within `qualifiers`.

--- a/docs/specification/standard/Annex-C-ABNF-Grammar.md
+++ b/docs/specification/standard/Annex-C-ABNF-Grammar.md
@@ -1,4 +1,4 @@
-# Annex B (informative) ABNF Grammar
+# Annex C (informative) ABNF Grammar
 This Annex documents the Augmented Backus Naur Form (ABNF) grammar for PURL strings.
 
 A valid PURL string adheres to the following grammar with the syntax defined

--- a/docs/specification/standard/Clause-3-Normative-References.md
+++ b/docs/specification/standard/Clause-3-Normative-References.md
@@ -1,14 +1,20 @@
 # 3 Normative References
 
 The following documents are referred to in the text in such a way that some or
- all of their content constitutes requirements of this document. For dated references, only the edition cited applies. For undated references, the 
+ all of their content constitutes requirements of this document. For dated references, only the edition cited applies. For undated references, the
  latest edition of the referenced document (including any amendments) applies.
 
 ECMA-262, ECMAScript® language specification
 https://ecma-international.org/publications-and-standards/standards/ecma-262/
 
+RFC 3629, UTF-8, a transformation format of ISO 10646
+https://datatracker.ietf.org/doc/html/rfc3629
+
 RFC 3986, Uniform Resource Identifier (URI): Generic Syntax
 https://datatracker.ietf.org/doc/html/rfc3986
+
+RFC 5234, Augmented BNF for Syntax Specifications: ABNF
+https://datatracker.ietf.org/doc/html/rfc5234
 
 The Unicode Standard
 https://www.unicode.org/versions/latest/

--- a/docs/specification/standard/Clause-5-Package-URL-Specification.md
+++ b/docs/specification/standard/Clause-5-Package-URL-Specification.md
@@ -113,12 +113,10 @@ This is how each of the Separator Characters is used:
 - In the "Rules for each PURL component" clause, each component
   defines when and how to apply percent-encoding and decoding to its content.
 - When percent-encoding is required by a component definition, the component
-  string shall first be encoded as UTF-8.
+  string shall first be encoded as UTF-8 per [RFC 3629](https://datatracker.ietf.org/doc/html/rfc3629).
 - In the component string, each "data octet" shall be replaced by the
   percent-encoded "character triplet" applying the percent-encoding mechanism
-  defined in [RFC 3986 section 2.1](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1),
-  including the RFC definition of "data octet" and "character triplet",
-  and using these definitions for RFC's "allowed set" and "delimiters":
+  defined in [RFC 3986 section 2.1](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1), including the RFC definition of "data octet" and "character triplet", and using these definitions for RFC's "allowed set" and "delimiters":
 
   - "allowed set" is composed of the Alphanumeric Characters and the
     Punctuation Characters
@@ -249,9 +247,9 @@ ignore and remove all such '/' characters.
 
 ## 5.7 PURL type definitions
 This Standard includes the Package-URL Type Definition Schema but it does not
-include the set of current "registered" PURL **type** (JSON format) definition 
-files because there are ongoing additions and changes to these files. The set 
-of current "registered" PURL **type** definition files are located at: https://www.packageurl.org/purl-types/. 
+include the set of current "registered" PURL **type** (JSON format) definition
+files because there are ongoing additions and changes to these files. The set
+of current "registered" PURL **type** definition files are located at: https://www.packageurl.org/purl-types/.
 Registration refers to the Package-URL community process for adding a new PURL **type**.
 
 There are two rules related to the set of registered PURL **type** definitions


### PR DESCRIPTION
Added Annex C - ABNF Grammar
Related changes to Clauses 3 and 5
Replaces the fine work of @jkowalleck on #578 because of the changes to file names for ECMA-427 files in the `purl-spec` repo