### PR TITLE
Update $id for 2nd edition schemas to purl schema

### DIFF
--- a/docs/specification/standard/Clause-6-Package-URL-Type-Definition-Schema.md
+++ b/docs/specification/standard/Clause-6-Package-URL-Type-Definition-Schema.md
@@ -9,7 +9,7 @@ The PURL Type Definition Schema is formally specified by a Draft 07 JSON
 Schema. Each published version of this specification is accompanied by a
 versioned meta-schema at a stable URI:
 
-https://packageurl.org/schemas/purl-type-definition.schema-<major>.<minor>.json
+https://packageurl.org/purl-schemas/purl-type-definition.schema-<major>.<minor>.json
 
 **Location:** /
 **Type:** Object

--- a/schemas/purl-test.schema-0.2.json
+++ b/schemas/purl-test.schema-0.2.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://packageurl.org/schemas/purl-test.schema-0.2.json",
+  "$id": "https://packageurl.org/purl-schemas/purl-test.schema-0.2.json",
   "title": "Package-URL test definition",
   "description": "Schema for Package-URL test cases.",
   "type": "object",

--- a/schemas/purl-type-definition.schema-1.1.json
+++ b/schemas/purl-type-definition.schema-1.1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
-  "$id": "https://packageurl.org/schemas/purl-type-definition.schema-1.1.json",
+  "$id": "https://packageurl.org/purl-schemas/purl-type-definition.schema-1.1.json",
   "title": "Package-URL Type Definition",
   "description": "Schema to specify a Package-URL (PURL) type as a structured definition.",
   "type": "object",

--- a/schemas/purl-types-index.schema-1.1.json
+++ b/schemas/purl-types-index.schema-1.1.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://packageurl.org/purl-schemas/purl-type-index.schema-1.0.json",
+  "title": "Package-URL types index",
+  "description": "An index of registered Package-URL types.",
+  "type": "array",
+  "additionalItems": false,
+  "items": {
+    "type": "string"
+  }
+}


### PR DESCRIPTION
Update the $id location of the PURL schema files for the 3 schema files that will be part of the ECMA-427 2nd Edition release
from: https://packageurl.org/schemas/
to: https://packageurl.org/purl-schemas/

No changes to the 1st Edition schemas. We will keep copies at the current location:
https://packageurl.org/schemas/purl-test.schema-0.1.json
https://packageurl.org/schemas/purl-type-definition.schema-1.0.json
https://packageurl.org/schemas/purl-types-index.schema-1.0.json

The only change to: purl-types-index.schema-1.0.json is the $id update for consistency.
