### PR TITLE
Update Annex B

### DIFF
--- a/docs/specification/standard/Annex-B-Recommended-Qualifiers.md
+++ b/docs/specification/standard/Annex-B-Recommended-Qualifiers.md
@@ -12,28 +12,34 @@ minimal set of **key=value** pairs that are necessary for accurate package
 identification or location. This restraint is necessary to ensure that PURLs
 stay compact and human readable.
 
+Tools that build PURLs should sort multiple **qualifiers** lexicographically
+by **key**, but this is not expected behaviour for a tool to parse or validate
+a PURL.
+
 ## B.2 ECMA-427 references
 The standards for the PURL **qualifiers** component and the **key=value**
 pairs are defined in two ECMA-427 clauses:
 - [Clause 5.6.6 Qualifiers](https://ecma-tc54.github.io/ECMA-427sec-purl-specification-rules-qualifiers)
 - [Clause 6.8  Qualifiers definition](https://ecma-tc54.github.io/ECMA-427/#sec--qualifiers-definition)
 
-
 ## B.3 Recommended qualifiers
 
 Many **qualifiers** are applicable to multiple PURL **types**. These qualifier
  **keys** should be used according to the following definitions.
 
-| qualifiers key | Definition                                |
+| key            | Definition                                  |
 |----------------|---------------------------------------------|
-| checksum       | One or more checksums stored as a comma-separated list. Each item in the **value** is in the form of 'lowercase_algorithm:hex_encoded_lowercase_value' such as sha1:ad9503c3e994a4f611a4892f2e67ac82df727086'      |
+| checksum       | One or more checksums stored as a comma-separated list.  |
 | download_url   | A URL for a direct package download URL    |
-| file_name      | The file name of a package archive. Use the **subpath** component for the use case where you need to specify a PURL at the file level.  |
-| repository_url | A URL for when the `default_repository_url` property is empty in a PURL **type** definition or when there are multiple commonly used repositories for a PURL. **type**.                                                          |
-| vcs_url        | A URL for a version control system (aka SCM or VCS) for the use case where you need to specify a PURL for a package at its SCM/VCS location. The syntax for 'vcs_url' should follow the Python pip syntax or the SPDX specification for ["Package Download Location"](https://github.com/spdx/spdx-spec/blob/cfa1b9d08903/chapters/3-package-information.md#3.7).                             |
-| vers           | Specification of a version range instead of a single version. The primary use cases for this **qualifiers key** are to identify a version range for dependency analysis or vulnerability reporting. Use of this **key** is mutually exclusive with the **version** component. The **value** must adhere to the [Version Range Specification](https://packageurl.org/docs/vers/specification). |
+| file_name      | The file name of a package archive.        |
+| repository_url | A URL for a package or software repository |
+| vcs_url        | A URL for a version control system (VCS) location |
+| vers           | A VERS notation that specifies a version range instead of a single version.  |
 
-### B.3.1 Checksum algorithm keys
+### B.3.1 checksum qualifier
+Each item in the **value** for a 'checksum' **qualifer** is in the form of
+lowercase_algorithm:hex_encoded_lowercase_value' such as sha1:ad9503c3e994a4f611a4892f2e67ac82df727086'
+
 The following standard 'checksum' **keys** should be used where applicable.
 This is not an exclusive list.
 
@@ -52,7 +58,35 @@ This is not an exclusive list.
 - SHA3-384 `sha3-384`
 - SHA3-512 `sha3-512`
 
+### B.3.2 download_url qualifier
+Most package managers provide a mechanism to derive a 'download-url' from the
+PURL data. Use this **qualifier** for the use case where the download URL for
+a package cannot be derived from the PURL or otherwise provided by the package
+manager. A 'download_url' **value** shall be percent-encoded.
 
+### B.3.3 file_name qualifier
+This **qualifier** is intended for the use case where you want to specify the
+name of a package archive or other file. Use the **subpath** component for the
+use case where you need to specify a PURL at the file level.
+
+### B.3.4 repository_url qualifier
+This **qualifier** is intended for the use cases where:
+- the 'default_repository_url' property is empty in a PURL **type** definition
+- there are multiple commonly used repositories for a PURL **type**
+
+A 'repository_url' **value** shall be percent-encoded.
+
+### B.3.5 vcs_url qualifier
+This **qualifier** is intended for the use case where you where you need to
+specify a PURL at its Version Control System location. The syntax for 'vcs_url'
+should follow the Python pip syntax or the SPDX specification for ["Package Download Location"](https://github.com/spdx/spdx-spec/blob/cfa1b9d08903/chapters/3-package-information.md#3.
+A 'vcs_url' **value** shall be percent-encoded.
+
+### B.3.6 vers qualifier
+The primary use cases for this **qualifier** are to identify a version range
+for dependency analysis or vulnerability reporting. Use of this **qualifier**
+is mutually exclusive with use of the **version** component. The **value** for
+a 'vers' **key** must adhere to the [Version Range Specification](https://packageurl.org/docs/vers/specification).
 
 ## B.4 Examples
 

--- a/docs/specification/standard/Annex-B-Recommended-Qualifiers.md
+++ b/docs/specification/standard/Annex-B-Recommended-Qualifiers.md
@@ -19,7 +19,7 @@ a PURL.
 ## B.2 ECMA-427 references
 The standards for the PURL **qualifiers** component and the **key=value**
 pairs are defined in two ECMA-427 clauses:
-- [Clause 5.6.6 Qualifiers](https://ecma-tc54.github.io/ECMA-427/sec-purl-specification-rules-qualifiers)
+- [Clause 5.6.6 Qualifiers](https://ecma-tc54.github.io/ECMA-427/#sec-purl-specification-rules-qualifiers)
 - [Clause 6.8  Qualifiers definition](https://ecma-tc54.github.io/ECMA-427/#sec--qualifiers-definition)
 
 ## B.3 Recommended qualifiers

--- a/docs/specification/standard/Annex-B-Recommended-Qualifiers.md
+++ b/docs/specification/standard/Annex-B-Recommended-Qualifiers.md
@@ -19,7 +19,7 @@ a PURL.
 ## B.2 ECMA-427 references
 The standards for the PURL **qualifiers** component and the **key=value**
 pairs are defined in two ECMA-427 clauses:
-- [Clause 5.6.6 Qualifiers](https://ecma-tc54.github.io/ECMA-427sec-purl-specification-rules-qualifiers)
+- [Clause 5.6.6 Qualifiers](https://ecma-tc54.github.io/ECMA-427/sec-purl-specification-rules-qualifiers)
 - [Clause 6.8  Qualifiers definition](https://ecma-tc54.github.io/ECMA-427/#sec--qualifiers-definition)
 
 ## B.3 Recommended qualifiers
@@ -29,16 +29,16 @@ Many **qualifiers** are applicable to multiple PURL **types**. These qualifier
 
 | key            | Definition                                  |
 |----------------|---------------------------------------------|
-| checksum       | One or more checksums stored as a comma-separated list.  |
+| checksum       | One or more checksums stored as a comma-separated list  |
 | download_url   | A URL for a direct package download URL    |
-| file_name      | The file name of a package archive.        |
+| file_name      | The file name of a package archive         |
 | repository_url | A URL for a package or software repository |
 | vcs_url        | A URL for a version control system (VCS) location |
-| vers           | A VERS notation that specifies a version range instead of a single version.  |
+| vers           | A VERS notation that specifies a version range instead of a single version  |
 
 ### B.3.1 checksum qualifier
 Each item in the **value** for a 'checksum' **qualifer** is in the form of
-lowercase_algorithm:hex_encoded_lowercase_value' such as sha1:ad9503c3e994a4f611a4892f2e67ac82df727086'
+'lowercase_algorithm:hex_encoded_lowercase_value' such as 'sha1:ad9503c3e994a4f611a4892f2e67ac82df727086'
 
 The following standard 'checksum' **keys** should be used where applicable.
 This is not an exclusive list.

--- a/docs/specification/standard/Annex-B-Recommended-Qualifiers.md
+++ b/docs/specification/standard/Annex-B-Recommended-Qualifiers.md
@@ -19,8 +19,8 @@ a PURL.
 ## B.2 ECMA-427 references
 The standards for the PURL **qualifiers** component and the **key=value**
 pairs are defined in two ECMA-427 clauses:
-- [Clause 5.6.6 Qualifiers](https://ecma-tc54.github.io/ECMA-427/#sec-purl-specification-rules-qualifiers)
-- [Clause 6.8  Qualifiers definition](https://ecma-tc54.github.io/ECMA-427/#sec--qualifiers-definition)
+- *Clause 5.6.6 Qualifiers*
+- *Clause 6.9.1 Qualifiers definition*
 
 ## B.3 Recommended qualifiers
 

--- a/docs/specification/standard/Annex-B-Recommended-Qualifiers.md
+++ b/docs/specification/standard/Annex-B-Recommended-Qualifiers.md
@@ -66,8 +66,8 @@ Example:
       pkg:generic/openssl@1.1.10g?checksum=sha1:ad9503c3e994a4f%2Csha256:41bf9088b3a1e6c1ef1d
 
 ### B.3.2 download_url qualifier
-Most package managers provide a mechanism to derive a 'download-url' from the
-PURL data. Use this **qualifier** for the use case where the download URL for
+Most package managers provide a mechanism to derive a 'download-url' from
+PURL data. Use this **qualifier** for the use cases where the download URL for
 a package cannot be derived from the PURL or otherwise provided by the package
 manager. A 'download_url' **value** shall be percent-encoded.
 
@@ -76,12 +76,13 @@ Example:
       pkg:generic/openssl@1.1.10g?download_url=https:%2F%2Fopenssl.org%2Fsource%2Fopenssl-1.1.0g.tar.gz
 
 ### B.3.3 file_name qualifier
-This **qualifier** is intended for the use case where you want to specify the
+This **qualifier** is intended for the use case where you need to specify the
 name of a package archive or other file. Use the **subpath** component for the
 use case where you need to specify a PURL at the file level.
 
-Example:
+Examples:
 
+      pkg:pypi/django@1.11.1?file_name=Django-1.11.1.tar.gz
       pkg:pypi/django@1.11.1?file_name=Django-1.11.1-py2.py3-none-any.whl
 
 ### B.3.4 repository_url qualifier
@@ -109,22 +110,21 @@ The syntax is:
 
 This compact VCS location notation supports referencing locations in version
 control systems such as Git, Mercurial, Subversion and Bazaar, and specifies
-the type of VCS tool using url prefixes: 'git+', 'hg+', 'bzr+', svn+ and
+the type of VCS tool using url prefixes: 'git+', 'hg+', 'bzr+', 'svn+' and
 specific transport schemes such as SSH or HTTPS.
 
-Specifying sub-paths, branch names, a commit hash, a revision or a tag name is
-recommended, and supported using the '@' delimiter for commit **versions** and
-the '#' delimiter for **sub-paths**.
-
 Using user names and password in the **host_name** is not supported and should
-be reported by tools as an error. User access control to URLs or VCS
-repositories shall be handled outside of an SPDX document.
+be reported by tools as an error.
+
+Specifying sub-paths, branch names, a commit hash, a revision or a tag name is
+recommended, and supported, using the '@' delimiter for a commit **version**
+and the '#' delimiter for a **sub-path**.
 
 In VCS location compact notations, the trailing slashes in **host_name**, and **path_to_repository** are not significant. Leading and trailing slashes in
 **sub_path** are not significant.
 
-- The supported schemes for Git are: 'git', 'git+git', 'git+https', 'git+http',
-  and 'git+ssh'. 'git' and 'git+git' are equivalent.
+- The supported schemes for Git are: 'git', 'git+git', 'git+https',
+  'git+http', and 'git+ssh'. 'git' and 'git+git' are equivalent.
 - The supported schemes for Mercurial are: 'hg+http', 'hg+https',
   'hg+static-http', and 'hg+ssh'.
 - The supported schemes for Subversion are: 'svn', 'svn+svn', 'svn+http',

--- a/docs/specification/standard/Annex-B-Recommended-Qualifiers.md
+++ b/docs/specification/standard/Annex-B-Recommended-Qualifiers.md
@@ -79,7 +79,36 @@ A 'repository_url' **value** shall be percent-encoded.
 ### B.3.5 vcs_url qualifier
 This **qualifier** is intended for the use case where you where you need to
 specify a PURL at its Version Control System location. The syntax for 'vcs_url'
-should follow the Python pip syntax or the SPDX specification for ["Package Download Location"](https://github.com/spdx/spdx-spec/blob/cfa1b9d08903/chapters/3-package-information.md#3.
+is based on Python pip syntax at: https://pip.pypa.io/en/stable/topics/vcs-support/
+The syntax is:
+
+      <vcs_tool>+<transport>://<host_name>[/<path_to_repository>][@<revision_tag_or_branch>]#<sub_path>]
+
+This compact VCS location notation supports referencing locations in version
+control systems such as Git, Mercurial, Subversion and Bazaar, and specifies
+the type of VCS tool using url prefixes: 'git+', 'hg+', 'bzr+', svn+ and
+specific transport schemes such as SSH or HTTPS.
+
+Specifying sub-paths, branch names, a commit hash, a revision or a tag name is
+recommended, and supported using the '@' delimiter for commit **versions** and
+the '#' delimiter for **sub-paths**.
+
+Using user names and password in the **host_name** is not supported and should
+be reported by tools as an error. User access control to URLs or VCS
+repositories shall be handled outside of an SPDX document.
+
+In VCS location compact notations, the trailing slashes in **host_name**, and **path_to_repository** are not significant. Leading and trailing slashes in
+**sub_path** are not significant.
+
+- The supported schemes for Git are: 'git', 'git+git', 'git+https', 'git+http',
+  and 'git+ssh'. 'git' and 'git+git' are equivalent.
+- The supported schemes for Mercurial are: 'hg+http', 'hg+https',
+  'hg+static-http', and 'hg+ssh'.
+- The supported schemes for Subversion are: 'svn', 'svn+svn', 'svn+http',
+  'svn+https', and 'svn+ssh'. 'svn and 'svn+svn' are equivalent.
+- The supported schemes for Bazaar are: 'bzr+http', 'bzr+https', 'bzr+ssh',
+  'bzr+sftp', 'bzr+ftp', and 'bzr+lp'.
+
 A 'vcs_url' **value** shall be percent-encoded.
 
 ### B.3.6 vers qualifier
@@ -88,8 +117,7 @@ for dependency analysis or vulnerability reporting. Use of this **qualifier**
 is mutually exclusive with use of the **version** component. The **value** for
 a 'vers' **key** must adhere to the [Version Range Specification](https://packageurl.org/docs/vers/specification).
 
-## B.4 Examples
-
+Example:
 
       pkg:pypi/django?vers=vers:pypi%2F%3E%3D1.11.0%7C%21%3D1.11.1%7C%3C2.0.0
 

--- a/docs/specification/standard/Annex-B-Recommended-Qualifiers.md
+++ b/docs/specification/standard/Annex-B-Recommended-Qualifiers.md
@@ -39,24 +39,31 @@ Many **qualifiers** are applicable to multiple PURL **types**. These qualifier
 ### B.3.1 checksum qualifier
 Each item in the **value** for a 'checksum' **qualifer** is in the form of
 'lowercase_algorithm:hex_encoded_lowercase_value' such as 'sha1:ad9503c3e994a4f611a4892f2e67ac82df727086'
+Multiple 'checksum' values are separated by an encoded comma ('%2C').
 
 The following standard 'checksum' **keys** should be used where applicable.
 This is not an exclusive list.
 
-- BLAKE2b-256 `blake2b-256` (used by pypi)
-- BLAKE3 `blake3`
-- MD5 `md5` (used by pypi maven)
-- RIPEMD-160 `ripemd160`
-- SHAKE256 `shake256`
-- SHA1 `sha1` (used by maven npm)
-- SHA2-224 `sha224`
-- SHA2-256 `sha256` (used by cargo gem maven npm)
-- SHA2-384 `sha384` (used by npm)
-- SHA2-512 `sha512` (used by npm nuget)
-- SHA3-224 `sha3-224`
-- SHA3-256 `sha3-256`
-- SHA3-384 `sha3-384`
-- SHA3-512 `sha3-512`
+| algorithm   | key         | used by                |
+| ----------- | ----------- | ---------------------- |
+| BLAKE2b-256 | blake2b-256 | pypi                   |
+| BLAKE3      | blake3      |                        |
+| MD5         | md5         | maven, pypi            |
+| RIPEMD-160  | ripemd160   |                        |
+| SHAKE256    | shake256    |                        |
+| SHA1        | sha1        | maven, npm             |
+| SHA2-224    | sha224      |                        |
+| SHA2-256    | sha256      | cargo, gem, maven, npm |
+| SHA2-384    | sha384      | npm                    |
+| SHA2-512    | sha512      | npm ,nuget             |
+| SHA3-224    | sha3-224    |                        |
+| SHA3-256    | sha3-256    |                        |
+| SHA3-384    | sha3-384    |                        |
+| SHA3-512    | sha3-512    |                        |
+
+Example:
+
+      pkg:generic/openssl@1.1.10g?checksum=sha1:ad9503c3e994a4f%2Csha256:41bf9088b3a1e6c1ef1d
 
 ### B.3.2 download_url qualifier
 Most package managers provide a mechanism to derive a 'download-url' from the
@@ -64,10 +71,18 @@ PURL data. Use this **qualifier** for the use case where the download URL for
 a package cannot be derived from the PURL or otherwise provided by the package
 manager. A 'download_url' **value** shall be percent-encoded.
 
+Example:
+
+      pkg:generic/openssl@1.1.10g?download_url=https:%2F%2Fopenssl.org%2Fsource%2Fopenssl-1.1.0g.tar.gz
+
 ### B.3.3 file_name qualifier
 This **qualifier** is intended for the use case where you want to specify the
 name of a package archive or other file. Use the **subpath** component for the
 use case where you need to specify a PURL at the file level.
+
+Example:
+
+      pkg:pypi/django@1.11.1?file_name=Django-1.11.1-py2.py3-none-any.whl
 
 ### B.3.4 repository_url qualifier
 This **qualifier** is intended for the use cases where:
@@ -75,6 +90,14 @@ This **qualifier** is intended for the use cases where:
 - there are multiple commonly used repositories for a PURL **type**
 
 A 'repository_url' **value** shall be percent-encoded.
+
+Examples:
+
+      pkg:bazel/curl@8.8.0?repository_url=https:%2F%2Fexample.org%2Fbazel-registry
+
+      pkg:huggingface/microsoft/deberta-v3-base@559062ad13d311b87b2c455e67dcd5f1c8f65111?repository_url=https:%2F%2Fhub-ci.huggingface.co
+
+      pkg:maven/groovy/groovy@1.0?repository_url=https:%2F%2Fmaven.google.com
 
 ### B.3.5 vcs_url qualifier
 This **qualifier** is intended for the use case where you where you need to
@@ -110,6 +133,12 @@ In VCS location compact notations, the trailing slashes in **host_name**, and **
   'bzr+sftp', 'bzr+ftp', and 'bzr+lp'.
 
 A 'vcs_url' **value** shall be percent-encoded.
+
+Examples:
+
+      pkg:generic/bitwarderl?vcs_url=git%2Bhttps:%2F%2Fgit.fsfe.org%2Fdxtr%2Fbitwarderl%40cc55108da32
+
+      pkg:npm/mypackage@12.4.5?vcs_url=git:%2F%2Fhost.com%2F%2Fpath%2Fto%2Frepo.git%404345abcd34343
 
 ### B.3.6 vers qualifier
 The primary use cases for this **qualifier** are to identify a version range


### PR DESCRIPTION
Close to final draft for Annex B
The open questions are:
- For 'vcs_url'
   - Do we really want to refer to SPDX for the syntax? If so which version of SPDX? The current link is to an SPDX document that is 9 years old!
   - If we want to refer to SPDX 2.3 we should refer to https://spdx.github.io/spdx-spec/v2.3/package-information/#77-package-download-location-field
   - I cannot figure out what to reference for SPDX 3.0 - https://spdx.github.io/spdx-spec/v3.0.1/model/Software/Properties/downloadLocation/# does not offer much to work with
   - Do we really want to include the url prefixes: “git+”, “hg+”, “bzr+”, “svn+” and specific transport schemes such as SSH or HTTPS?
   - For pip the current reference seems to be: https://pip.pypa.io/en/stable/topics/vcs-support/
- For 'vers': Do we want to provide a URL for VERS because we will not have a "permanent" one for ECMA-VERS due to the fact that we are submitting PURL 2nd Edition and VERS 1st Edition in the same cycle?
- Are we missing any **qualifiers** that should be in Annex B?